### PR TITLE
adding section config for amazon prime day card

### DIFF
--- a/config/section.json
+++ b/config/section.json
@@ -12,6 +12,23 @@
         "type": "query",
         "value":  ".grid > :nth-child(14)"
       }
+    },
+    {
+      "id": "zone-el-amazon-prime-day",
+      "filters": [
+        {
+          "type": "config",
+          "name": "marketInfo.sourcelevel",
+          "value": "mcpshopping"
+        }
+      ],
+      "placement": {
+        "type": "query",
+        "value": ".grid > :nth-child(9)"
+      },
+      "zephr": {
+        "feature": "zone-amazon-prime-day"
+      }
     }
   ]
 }


### PR DESCRIPTION
### What does this PR do?

It adds a section configuration for the Amazon Prime Day card.

### Steps to test

1. Fire up a local server from the main zones repo directory in the new branch
2. Go to any of our shopping pages (https://www.kansas.com/shopping)
3. Open up netdale.xxx.js in DevTools and save for overrides
4. Search for the string `section.json`
5. Replace `/static/hi/zones/section.json` with `http://localhost:3000/config/section.json`
6. Reload the webpage and see if we're good.

### What it should look like

![www kansas com_shopping](https://github.com/mcclatchy/zones/assets/198070/9c6a7008-17c7-45f7-90f6-5076bb3341d5)
