### PR TITLE
change zone distribution cadence for non-subscribers to 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,11 +29,13 @@ function distributeZones(locker) {
         case "story":
           await config.load(locker.config.story);
 
-          // Set cadence for subsriber vs. nonsubscriber - testing different cadence for two markets
+          // Set cadence for subscriber vs. nonsubscriber vs. nonsubscriber out of market in test domains
           const subscriber = locker.user.isSubscriber();
+          const dma = subscriber ? true : await locker.user.isInDMA();
+          const nonsubscriberOutOfMarket = !subscriber && !dma;
           const domainName = locker.getConfig('domainName');
           const allowedDomains = ["https://www.bnd.com/", "https://www.myrtlebeachonline.com/"];
-          const cadence = allowedDomains.includes(domainName) ? (subscriber ? 4 : 2) : (subscriber ? 4 : 3);
+          const cadence = allowedDomains.includes(domainName) && nonsubscriberOutOfMarket ? 2 : (subscriber ? 4 : 3);
 
           zones.distribute(cadence);
 

--- a/index.js
+++ b/index.js
@@ -29,9 +29,12 @@ function distributeZones(locker) {
         case "story":
           await config.load(locker.config.story);
 
-          // Change the cadence
+          // Set cadence for subsriber vs. nonsubscriber - testing different cadence for two markets
           const subscriber = locker.user.isSubscriber();
-          const cadence = subscriber ? 4 : 2;
+          const domainName = locker.getConfig('domainName');
+          const allowedDomains = ["https://www.bnd.com/", "https://www.myrtlebeachonline.com/"];
+          const cadence = allowedDomains.includes(domainName) ? (subscriber ? 4 : 2) : (subscriber ? 4 : 3);
+
           zones.distribute(cadence);
 
           // Temporary cleanup
@@ -52,5 +55,8 @@ function distributeZones(locker) {
     });
   });
 }
+
+
+console.log(locker);
 
 export default distributeZones;

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function distributeZones(locker) {
 
           // Change the cadence
           const subscriber = locker.user.isSubscriber();
-          const cadence = subscriber ? 4 : 3;
+          const cadence = subscriber ? 4 : 2;
           zones.distribute(cadence);
 
           // Temporary cleanup

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function distributeZones(locker) {
           const dma = subscriber ? true : await locker.user.isInDMA();
           const nonsubscriberOutOfMarket = !subscriber && !dma;
           const domainName = locker.getConfig('domainName');
-          const allowedDomains = ["https://www.bnd.com/", "https://www.myrtlebeachonline.com/"];
+          const allowedDomains = ["www.bnd.com", "www.myrtlebeachonline.com"];
           const cadence = allowedDomains.includes(domainName) && nonsubscriberOutOfMarket ? 2 : (subscriber ? 4 : 3);
 
           zones.distribute(cadence);

--- a/index.js
+++ b/index.js
@@ -58,7 +58,4 @@ function distributeZones(locker) {
   });
 }
 
-
-console.log(locker);
-
 export default distributeZones;


### PR DESCRIPTION
### What does this PR do?

It updates the cadence/frequency of zone placements on story pages for non-subscribers to 2 as opposed to 3. This is more specifically part of a test by the ad team with the purpose of gathering data on ad impressions over a 48 hour period. 

### Steps to test

1. Go to any of our story pages
2. Open up netdale.xxx.js in DevTools and save for overrides
3. Search for the string `4 : 3`
4. Replace `4 : 3` with `4 : 2`
5. Reload the webpage and check that the zones show up every 2 paragraphs.

PS: The above steps do not directly test from the new feature branch. A proper test would require a rebuild of the netdale file, which I do not have the resources for. There is only one character change in this update, so it's very straightforward. Please let me know if there are any questions.