### PR TITLE
bug: fixing query placement on stories outside of the body

### DIFF
--- a/demo/locker.js
+++ b/demo/locker.js
@@ -27,7 +27,7 @@ const locker = {
       case "zone.zeeto":
         return true;
       case "zone.moneycom":
-        return false;
+        return true;
       case "zone.communityEvents":
         return true;
       case "zone.taboolaRecommendations":

--- a/lib/zones.js
+++ b/lib/zones.js
@@ -376,8 +376,10 @@ export function distribute(tick = 4) {
   const cadence = tick;
 
   map.forEach(zone => {
-    zone.vip = vips[tick];
-    tick += cadence;
+    if(!zone.vip) {
+      zone.vip = vips[tick];
+      tick += cadence;
+    }
   });
 }
 


### PR DESCRIPTION
### What does this PR do?

It fixes a bug where the vip for story zones set outside of the story body was being overloaded in the `zones.distribute()` function.

### Steps to test

1. Fire up a local server and go to the [story page](http://localhost:3000/demo/story/)
2. Replace the `config/story.json` file with the attached version.
3. Reload and you should see a money.com zone above the story body.
[bug-story-query.zip](https://github.com/mcclatchy/zones/files/12325316/bug-story-query.zip)

### What it should look like
![Screenshot 2023-08-11 4 35 16 PM](https://github.com/mcclatchy/zones/assets/198070/9d83feec-0bdd-4f8c-853a-354029f63a8a)