### PR TITLE
New siTickets and gamecocksNav zones

### DIFF
--- a/config/story.json
+++ b/config/story.json
@@ -21,8 +21,8 @@
         "feature": "zone-moneycom"
       },
       "placement": {
-        "type": "query",
-        "value": ".story-body"
+        "type": "after",
+        "value": "zone-el-101"
       }
     },
     {

--- a/config/story.json
+++ b/config/story.json
@@ -21,8 +21,8 @@
         "feature": "zone-moneycom"
       },
       "placement": {
-        "type": "after",
-        "value": "zone-el-101"
+        "type": "query",
+        "value": ".story-body"
       }
     },
     {
@@ -46,6 +46,36 @@
       "placement": {
         "type": "after",
         "value": "zone-el-101"
+      }
+    },
+    {
+      "id": "zone-si-tickets",
+      "cue": 278143207,
+      "filters": [
+        {
+          "type": "config",
+          "name": "zone.siTickets",
+          "value": true
+        }
+      ],
+      "placement": {
+        "type": "after",
+        "value": "zone-el-101"
+      }
+    },
+    {
+      "id": "zone-gamecocks-nav",
+      "cue": 278142507,
+      "filters": [
+        {
+          "type": "config",
+          "name": "zone.gamecocksNav",
+          "value": true
+        }
+      ],
+      "placement": {
+        "type": "query",
+        "value": ".story-body"
       }
     }
   ]

--- a/demo/locker.js
+++ b/demo/locker.js
@@ -27,10 +27,14 @@ const locker = {
       case "zone.zeeto":
         return true;
       case "zone.moneycom":
-        return true;
+        return false;
       case "zone.communityEvents":
         return true;
       case "zone.taboolaRecommendations":
+        return true;
+      case "zone.siTickets":
+        return true;
+      case "zone.gamecocksNav":
         return true;
       default: 
         return undefined;


### PR DESCRIPTION
### What does this PR do?

**_This should only be released after Zones 1.5.0 is in production._**

Adds two new CUE zones to the story config:
- siTickets = an iframe from Sports Illustrated for Gamecocks tickets
- gamecocksNav = section navigation for article pages

### Steps to test

1. Fire up a local server of the repo on 3000
2. Go to the demo story page (http://localhost:3000/demo/story/)
3. Replace the `story.json` file with [this version](https://raw.githubusercontent.com/mcclatchy/zones/677ba736cadd826e479cd3b0b5e61004ab6b6283/config/story.json) from the PR.
4. Reload the page and confirm:
    - the new siTickets zone is rendering above `zone-el-101`
    - the new gamecocksNav zone is rendering above `.story-body`

### What you should see

<img width="1475" alt="Screenshot 2023-08-14 at 11 08 22 AM" src="https://github.com/mcclatchy/zones/assets/1643734/124aa14f-3fc4-4ac2-906d-1a2f2be3ba66">
<img width="833" alt="Screenshot 2023-08-14 at 10 49 18 AM" src="https://github.com/mcclatchy/zones/assets/1643734/90113385-0339-47c9-9670-7f7e8f5b76fd">
