### PR TITLE
adding zone-el-9 and zone-el-11 back to homepages

### DIFF
--- a/config/homepage.json
+++ b/config/homepage.json
@@ -24,6 +24,60 @@
         "type": "query",
         "value": "#zone-el-5"
       }
+    },
+    {
+      "id": "zone-community-events",
+      "type": "editorial",
+      "notes": "duped for the new DOM",
+      "filters": [
+        {
+          "type": "config",
+          "name": "zone.communityEventsNew",
+          "value": true
+        }
+      ],
+      "zephr": {
+        "feature": "zone-community-events",
+        "dataset": [
+          {
+            "type": "config",
+            "name": "market",
+            "value": "marketInfo.domain"
+          }
+        ]
+      },
+      "placement": {
+        "type": "query",
+        "value": "#secondary-story-9"
+      }
+    },
+    {
+      "id": "zone-el-9",
+      "filters": [
+        {
+          "type": "config",
+          "name": "zone.communityEventsNew",
+          "value": true
+        }
+      ],
+      "placement": {
+        "type": "query",
+        "value": "#secondary-story-6"
+      }
+    },
+    {
+      "id": "zone-el-11",
+      "filters": [
+        {
+          "type": "config",
+          "name": "zone.communityEventsNew",
+          "value": true
+        }
+      ],
+      "placement": {
+        "type": "query",
+        "value": "#secondary-story-14"
+      }
     }
   ]
 }


### PR DESCRIPTION
### What does this PR do?

Two ad zones weren't brought over in the refactor, and this adds them back in. This is a test of the repo's capability to add standard zones dynamically that are then filled by the Performance Team. If successful, we should expand this capability over the remainder of the year.

### Steps to test

1. Place the `homepage.json` config file in the appropriate Overrides location (www.kansas.com/static/hi/zones/homepage.json)
2. Reload kansas.com, and check in DevTools for `zone-el-9` and `zone-el-11`

_These zones do not load consistently, so a DevTools check is the best we got. Check out the config file for the placement._