### PR TITLE
adding sponsored article disclaimer zone

### DIFF
--- a/config/story.json
+++ b/config/story.json
@@ -77,6 +77,22 @@
         "type": "query",
         "value": ".story-body"
       }
+    },
+    {
+      "id": "zone-sponsored-article",
+      "cue": 277282728,
+      "filters": [
+        {
+          "type": "config",
+          "name": "zone.sponsoredArticle",
+          "value": true
+        }
+      ],
+      "placement": {
+        "type": "query",
+        "value": ".story-body > .header"
+      },
+      "classList": ["hidden"]
     }
   ]
 }

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -2,7 +2,7 @@
  * Demo supplements
  */
 
-.card, .zone {
+.card {
   min-height: 300px;
 }
 
@@ -24,12 +24,12 @@
 
 [id^=zone-] {
   display: block !important;
-  min-height: 300px;
-  background-color: blue !important;
+  background-color: blue;
+  --ad-background: blue;
 }
 
 [id^=zone-][data-distributed] {
-  background-color: green !important;
+  background-color: green;
 }
 
 [id^=zone-]:before {

--- a/demo/locker.js
+++ b/demo/locker.js
@@ -22,10 +22,6 @@ const locker = {
         return "miamiherald";
       case "marketInfo.taxonomy":
         return "News/Sports//";
-      case "zone.carousel":
-        return true;
-      case "zone.zeeto":
-        return true;
       case "zone.moneycom":
         return false;
       case "zone.communityEvents":
@@ -33,8 +29,10 @@ const locker = {
       case "zone.taboolaRecommendations":
         return true;
       case "zone.siTickets":
-        return true;
+        return false;
       case "zone.gamecocksNav":
+        return false;
+      case "zone.sponsoredArticle":
         return true;
       default: 
         return undefined;

--- a/demo/section/index.html
+++ b/demo/section/index.html
@@ -23,8 +23,8 @@
   </head>
 
   <body>
-    <div id="zone-el-1"></div>
-    <div id="zone-el-2"></div>
+    <!-- <div id="zone-el-1"></div> -->
+    <!-- <div id="zone-el-2"></div> -->
     <div class="card flag"></div>
 
     <section class="grid">


### PR DESCRIPTION
### What does this PR do?

It adds a new zone tied to a `zone.sponsoredArticle` section config that renders the words "SPONSORED CONTENT" above the `.header` element. It uses CSS to do this, and the payload is stored in CUE.

#### Notes

This is a replication of an Article Widget 1 concept, but better. I also reset the local `locker.js` file to hide some previous customizations, and remove some dead ones. Lastly, I also changed the demo CSS a bit to make the zones smaller by default on story pages.

I'm adding a hidden class on this zone because it's CSS only. The `demo.css` file is forcing the block display so we can confirm it's working. The zone should collapse in production. If it doesn't I'll adjust.

### Steps to test

1. Pull down the branch.
2. Fire up your local server and go to the [story page](http://localhost:3000/demo/story/)

### What you should see

![image](https://github.com/mcclatchy/zones/assets/198070/4c625331-0813-4c58-8a5f-6cd0ec1ea5b4)