### PR TITLE
Zone tracking

### DIFF
--- a/config/story.json
+++ b/config/story.json
@@ -3,10 +3,6 @@
   "ignore": ["zone-el-16"],
   "zones": [
     {
-      "id": "zone-el-101",
-      "tracking": true
-    },
-    {
       "id": "zone-moneycom",
       "filters": [
         {
@@ -50,7 +46,8 @@
       "placement": {
         "type": "after",
         "value": "zone-el-101"
-      }
+      },
+      "tracking": true
     },
     {
       "id": "zone-si-tickets",

--- a/config/story.json
+++ b/config/story.json
@@ -3,29 +3,6 @@
   "ignore": ["zone-el-16"],
   "zones": [
     {
-      "id": "zone-moneycom",
-      "filters": [
-        {
-          "type": "config",
-          "name": "zone.moneycom",
-          "value": true
-        },
-        {
-          "type": "config",
-          "name": "articleCredit",
-          "pattern": "(Paradise Media|Bankrate)",
-          "value": false
-        }
-      ],
-      "zephr": {
-        "feature": "zone-moneycom"
-      },
-      "placement": {
-        "type": "after",
-        "value": "zone-el-101"
-      }
-    },
-    {
       "id": "zone-taboola-recommendations",
       "filters": [
         {

--- a/config/story.json
+++ b/config/story.json
@@ -3,6 +3,10 @@
   "ignore": ["zone-el-16"],
   "zones": [
     {
+      "id": "zone-el-101",
+      "tracking": true
+    },
+    {
       "id": "zone-moneycom",
       "filters": [
         {

--- a/demo/locker.js
+++ b/demo/locker.js
@@ -27,7 +27,7 @@ const locker = {
       case "zone.communityEvents":
         return true;
       case "zone.taboolaRecommendations":
-        return true;
+        return false;
       case "zone.siTickets":
         return false;
       case "zone.gamecocksNav":

--- a/demo/locker.js
+++ b/demo/locker.js
@@ -27,7 +27,7 @@ const locker = {
       case "zone.communityEvents":
         return true;
       case "zone.taboolaRecommendations":
-        return false;
+        return true;
       case "zone.siTickets":
         return false;
       case "zone.gamecocksNav":

--- a/demo/story/index.html
+++ b/demo/story/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" data-pagetype="story">
   <head>
-    <title>Zones section demo</title>
+    <title>Zones story demo</title>
     <link rel="icon" type="image/x-icon" href="https://www.kansascity.com/favicon.ico">
     
     <meta charset="UTF-8">
@@ -19,24 +19,24 @@
       import distributeZones from "/index.js";
 
       // Mimic the Yozons implementation
-      distributeZones(locker).then(msg => { console.log(msg) });
+      distributeZones(locker);
 
       // Listen for the loaded event
       window.addEventListener("zones-loaded", console.log("zones are loaded"));
 
       // Listen for the intersection event
-      window.addEventListener("zone", (e) => console.log("%s showing", e.detail.id));
+      window.addEventListener("zone", (e) => console.log("zone showing: %s", JSON.stringify(e.detail)));
+
+      // Listen for tracking events
+      window.addEventListener("trackcustomzones", (e) => console.log("zone tracked: %s", JSON.stringify(e.detail)));
 
       // Demo-only show vips
       import { getValidInsertionPoints } from "/lib/zones.js";
-      const vips = getValidInsertionPoints();
-      vips.forEach(ele => ele.classList.add("vip"));
+      getValidInsertionPoints().forEach(ele => ele.classList.add("vip"));
     </script>
   </head>
 
   <body>
-    <!-- <div id="zone-el-1"></div> -->
-    <!-- <div id="zone-el-2"></div> -->
     <div class="card flag"></div>
 
     <article class="paper story-body">

--- a/lib/config.js
+++ b/lib/config.js
@@ -31,11 +31,11 @@ export function load(url) {
     // Loop through changes
     const zones = data.zones || [];
     zones.forEach(config => {
-      let check = true;
+      let show = true;
 
       // Filter check
       if(config.filters) {
-        check = config.filters.every(f => {
+        show = config.filters.every(f => {
           const { type, name, value, pattern } = f;
 
           switch(type) {
@@ -61,7 +61,7 @@ export function load(url) {
       }
 
       // Render 
-      if(check) {
+      if(show) {
         const zone = new Zone(config.id);
 
         // Zephr connection
@@ -104,6 +104,11 @@ export function load(url) {
         // Add type
         if(config.type) {
           zone.dataset.type = config.type;
+        }
+
+        // Add tracking
+        if(config.tracking) {
+          zone.tracking = true;
         }
 
         // Placement

--- a/lib/zones.js
+++ b/lib/zones.js
@@ -446,7 +446,7 @@ function handleTracking(entries, observer) {
         detail: {
           data: [
             {
-              name: entry.target.id,
+              zone: entry.target.id.replace(/zone-(el-)?/, ''),
               action: "impression",
               count: 1
             }

--- a/lib/zones.js
+++ b/lib/zones.js
@@ -5,7 +5,8 @@
 // Internals
 let map = new Map();
 let fragment = new DocumentFragment();
-let observer = new IntersectionObserver(handleIntersection, { rootMargin: "500px" })
+let loadObserver = new IntersectionObserver(handleLoad, { rootMargin: "500px" });
+let trackingObserver = new IntersectionObserver(handleTracking, { threshold: 0.25 });
 
 // Locker
 export let locker;
@@ -53,6 +54,18 @@ export class Zone {
 
     // Add this zone to the map
     map.set(val, this);
+  }
+
+  /*
+   * Getter/Setter for tracking
+   */
+
+  get tracking() {
+    return this.element.dataset.tracking;
+  }
+
+  set tracking(val) {
+    this.element.dataset.tracking = val;
   }
 
   /*
@@ -153,7 +166,12 @@ export class Zone {
       this.log(this.msg || "zone moved into new location");
 
       // Observer for performance team
-      observer.observe(this.element);
+      loadObserver.observe(this.element);
+
+      // Tracking observer
+      if(this.tracking) {
+        trackingObserver.observe(this.element);
+      }
     }
   }
 
@@ -394,24 +412,53 @@ export function render() {
 }
 
 /*
- * IntersectionObserver callback
+ * Intersection callback
  */
 
-function handleIntersection(entries, observer) {
+function handleLoad(entries, observer) {
   entries.forEach((entry) => {
     if(entry.isIntersecting) {
-      // Build the event
-      const loadZone = new CustomEvent("zone", {
+      // Build the load event
+      const intersectionEvent = new CustomEvent("zone", {
         detail: {
           id: entry.target.id
         }
       });
 
       // Send it
-      window.dispatchEvent(loadZone);
+      window.dispatchEvent(intersectionEvent);
 
-      // Only do it once
-      observer.unobserve(entry.target);
+      // Only do this once
+      loadObserver.unobserve(entry.target);
+    }
+  });
+}
+
+/*
+ * Tracking callback
+ */
+
+function handleTracking(entries, observer) {
+  entries.forEach((entry) => {
+    if(entry.isIntersecting) {
+      // Build the tracking event if configured (Joe Grubbs spec)
+      const trackEvent = new CustomEvent('trackcustomzones', {
+        detail: {
+          data: [
+            {
+              name: entry.target.id,
+              action: "impression",
+              count: 1
+            }
+          ]
+        }
+      });
+
+      // Send it
+      window.dispatchEvent(trackEvent);
+
+      // Only do this once
+      trackingObserver.unobserve(entry.target);
     }
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcclatchy/zones",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "description": "A Yozons extension to dynamically distribute or re-distribute zones on the websites.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### What does this PR do?

It adds Amplitude tracking capabilities to zones. To enable in the configuration layer, simply add `"tracking": true` to any zone. 

#### Note

We should not add tracking to standard zones. The Performance Team already has this functionality. Only use this for custom zones like `zone-taboola-recommendations`.

### Steps to test (easy version)

1. Pull down the feature branch and fire up your local server.
2. Load the [story page](http://localhost:3000/demo/story/) and open DevTools.
3. Scroll down to the `zone-taboola-recommendations` zone.
4. Check in Devtools for the following line.

```
zone tracked: {"data":[{"zone":"taboola-recommendations","action":"impression","count":1}]}
```

### Steps to test (hard version)

This is a live test using Overrides and an Amplitude Chrome Extension to verify the `$exposure` event fired.

1. Install the [Amplitude Event Explorer](https://chrome.google.com/webstore/detail/amplitude-event-explorer/acehfjhnmhbmgkedjmjlobpgdicnhkbp) Chrome extension 
2. Download the [overrides.zip](https://github.com/mcclatchy/zones/files/12443657/overrides.zip) file and unzip it into your local overrides folder
3. Go to [this article](https://www.newsobserver.com/entertainment/article278522374.html) on the N&O site.
4. Open the extension. You should see several events already registered. It helped me to expand it using the icon.
5. Scroll down to the Taboola zone near the bottom.
6. Confirm the `$exposure` event triggered with the payload listed above

### What the extension should look like

![image](https://github.com/mcclatchy/zones/assets/198070/602598a6-2544-41b0-9e6f-4b869092519a)
