### PR TITLE
Config cadence

### DIFF
--- a/config/story.json
+++ b/config/story.json
@@ -4,7 +4,7 @@
   "cadence": {
     "subscriber": 4,
     "dma": 3,
-    "default": 2
+    "standard": 2
   },
   "zones": [
     {

--- a/config/story.json
+++ b/config/story.json
@@ -1,6 +1,11 @@
 {
   "base": ".story-body [id^=zone-el]",
   "ignore": ["zone-el-16"],
+  "cadence": {
+    "subscriber": 4,
+    "dma": 3,
+    "default": 2
+  },
   "zones": [
     {
       "id": "zone-taboola-recommendations",

--- a/demo/locker.js
+++ b/demo/locker.js
@@ -42,7 +42,7 @@ const locker = {
   // user info
   user: {
     isSubscriber() {
-      return false;
+      return true;
     },
 
     isLoggedIn() {
@@ -50,7 +50,7 @@ const locker = {
     },
 
     isInDMA() {
-      return Promise.resolve(true);
+      return Promise.resolve(false);
     }
   },
 

--- a/index.js
+++ b/index.js
@@ -10,11 +10,11 @@ function distributeZones(locker) {
   // Setup
   zones.setLocker(locker);
 
-  // Configs 
+  // Config files 
   if(!locker.config) {
     locker.config = {
       homepage: "/static/hi/zones/homepage.json",
-      section: "/static/hi/zones/section.json",
+      sectfront: "/static/hi/zones/section.json",
       story: "/static/hi/zones/story.json"
     }
   }
@@ -25,28 +25,22 @@ function distributeZones(locker) {
   // Give the performance team a promise
   return new Promise((resolve, reject) => {
     locker.executeWhenDOMReady(async () => {
-      switch(locker.pageType) {
-        case "story":
-          await config.load(locker.config.story);
+      // Config keys match pageType coming from Yozons
+      const file = locker.config[locker.pageType];
 
-          // Set cadence for subscriber vs. nonsubscriber vs. nonsubscriber out of market in test domains
-          const subscriber = locker.user.isSubscriber();
-          const cadence = subscriber ? 4 : 2;
-          zones.distribute(cadence);
-
-          // Temporary cleanup
-          story.cleanup();
-          break;
-        case "homepage":
-          await config.load(locker.config.homepage);
-          break;
-        case "sectfront":
-          await config.load(locker.config.section);
-          break;
-        default:
-          reject("not a matching page type");
+      // Load config file
+      if(file) {
+        await config.load(file);
+      } else {
+        reject("not a matching page type");
       }
 
+      // Temporary cleanup
+      if(locker.pageType == "story") {
+        story.cleanup();
+      }
+
+      // Render and resolve
       zones.render();
       resolve("zones-loaded")
     });

--- a/index.js
+++ b/index.js
@@ -31,12 +31,7 @@ function distributeZones(locker) {
 
           // Set cadence for subscriber vs. nonsubscriber vs. nonsubscriber out of market in test domains
           const subscriber = locker.user.isSubscriber();
-          const dma = subscriber ? true : await locker.user.isInDMA();
-          const nonsubscriberOutOfMarket = !subscriber && !dma;
-          const domainName = locker.getConfig('domainName');
-          const allowedDomains = ["www.bnd.com", "www.myrtlebeachonline.com"];
-          const cadence = allowedDomains.includes(domainName) && nonsubscriberOutOfMarket ? 2 : (subscriber ? 4 : 3);
-
+          const cadence = subscriber ? 4 : 2;
           zones.distribute(cadence);
 
           // Temporary cleanup

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,7 +2,7 @@
  * JSON configuration support
  */
 
-import { locker, Zone, ignore } from "./zones.js";
+import { locker, Zone, ignore, distribute } from "./zones.js";
 
 /**
  * Loads a configuration file
@@ -14,6 +14,7 @@ export function load(url) {
   return new Promise(async (resolve, reject) => {
     const res = await fetch(url);
     const data = await res.json();
+    const template = locker.pageType;
     const subscriber = locker.user.isSubscriber();
     const dma = subscriber ? true : await locker.user.isInDMA();
 
@@ -134,6 +135,24 @@ export function load(url) {
         }
       }
     });
+
+    // Story page cadence distribution
+    if(locker.pageType == "story") {
+      let cadence;
+
+      switch(true) {
+        case subscriber:
+          cadence = data.cadence.subscriber;
+          break;
+        case dma:
+          cadence = data.cadence.dma;
+          break
+        default:
+          cadence = data.cadence.standard;
+      }
+
+      distribute(cadence);
+    }
 
     resolve();
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcclatchy/zones",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A Yozons extension to dynamically distribute or re-distribute zones on the websites.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### What does this PR do?

It moves the cadence logic into the config.js file, allowing us to pass it in through the config json files. It also cleans up the index.js file a bit to match.

_Note: the test of setting the cadence to two for out-of-market readers passed and Nick wanted to scale that out. This release also remove the test filters._

### Steps to test

1. Fire up the demo on a local server and go to the [story page](http://localhost:3000/demo/story/).
2. Open the `demo/locker.js` file and alter the return values for the `user.isSubscriber()` and `user.isInDMA()` functions to see the different cadence. The values should be 4 for subscribers, 3 for dma, and 2 for everyone else.