### PR TITLE
adding local news digest to stories

### DIFF
--- a/config/story.json
+++ b/config/story.json
@@ -71,6 +71,36 @@
         "value": ".story-body > .header"
       },
       "classList": ["hidden"]
+    },
+    {
+      "id": "zone-local-news-digest",
+      "tracking": true,
+      "filters": [
+        {
+          "type": "config",
+          "name": "zone.localNewsDigest",
+          "value": true
+        },
+        {
+          "type": "dma",
+          "value": true
+        }
+      ],
+      "zephr": {
+        "feature": "zone-local-news-digest",
+        "dataset": [
+          {
+            "type": "config",
+            "name": "domain",
+            "value": "marketInfo.domain"
+          }
+        ]
+      },
+      "placement": {
+        "type": "after",
+        "value": "zone-el-101"
+      },
+      "classList": ["stn-player"]
     }
   ]
 }


### PR DESCRIPTION
### What does this PR do?

It adds a local recirculation digest using the [custom-digest](https://mcclatchy.github.io/cards/custom-digest/) card after `zone-el-101` for in-market readers and subscribers.

### Steps to test

1. Download this [overrides.zip](https://github.com/mcclatchy/zones/files/12501375/overrides.zip) file and unzip it into your local overrides folder.
2. Go to [this arcitle](https://www.bnd.com/article278861404.html) on bnd.com, enable overrides and make sure you're logged in as a subscriber.

### What you should see (headlines might change)
![image](https://github.com/mcclatchy/zones/assets/198070/4d165af2-436c-4c10-9818-34a42db799ab)
