### PR TITLE
rejecting config.load on error

### DIFF
--- a/demo/story/index.html
+++ b/demo/story/index.html
@@ -19,7 +19,9 @@
       import distributeZones from "/index.js";
 
       // Mimic the Yozons implementation
-      distributeZones(locker);
+      distributeZones(locker)
+        .then(() => { console.log("zones: clean render") })
+        .catch((e) => { console.warn(e) });
 
       // Listen for the loaded event
       window.addEventListener("zones-loaded", console.log("zones are loaded"));

--- a/index.js
+++ b/index.js
@@ -26,13 +26,17 @@ function distributeZones(locker) {
   return new Promise((resolve, reject) => {
     locker.executeWhenDOMReady(async () => {
       // Config keys match pageType coming from Yozons
-      const file = locker.config[locker.pageType];
+      const match = locker.config[locker.pageType];
 
       // Load config file
-      if(file) {
-        await config.load(file);
+      if(match) {
+        try {
+          await config.load(match);
+        } catch(e) {
+          reject(e);
+        }
       } else {
-        reject("not a matching page type");
+        reject("zones: not a matching page type");
       }
 
       // Temporary cleanup

--- a/lib/config.js
+++ b/lib/config.js
@@ -12,8 +12,24 @@ import { locker, Zone, ignore, distribute } from "./zones.js";
 
 export function load(url) {
   return new Promise(async (resolve, reject) => {
+    let data;
     const res = await fetch(url);
-    const data = await res.json();
+
+    // Reject if file missing
+    if(!res.ok) {
+      reject("zones: missing config file");
+      return;
+    }
+
+    // Reject if file is not JSON
+    try {
+      data = await res.json();
+    } catch(e) {
+      reject("zones: config file not JSON");
+      return;
+    }
+
+    // Configs
     const template = locker.pageType;
     const subscriber = locker.user.isSubscriber();
     const dma = subscriber ? true : await locker.user.isInDMA();


### PR DESCRIPTION
QA does not have the bucket synced like production, and we were not properly rejecting our promise in that environment. This update adds that so the performance team can pick up on it and make a decision about what to do.