### PR TITLE
adding lexgo eat sponsor to story pages

### DIFF
--- a/config/story.json
+++ b/config/story.json
@@ -106,6 +106,21 @@
         "value": "zone-el-101"
       },
       "classList": ["stn-player"]
+    },
+    {
+      "id": "zone-lexgoeat-sponsor",
+      "cue": 266575046,
+      "filters": [
+        {
+          "type": "config",
+          "name": "sectionID",
+          "value": "43881"
+        }
+      ],
+      "placement": {
+        "type": "query",
+        "value": ".story-body" 
+      }
     }
   ]
 }

--- a/config/story.json
+++ b/config/story.json
@@ -113,8 +113,8 @@
       "filters": [
         {
           "type": "config",
-          "name": "sectionID",
-          "value": "43881"
+          "name": "zone.lexgoEatSponsor",
+          "value": true
         }
       ],
       "placement": {

--- a/demo/locker.js
+++ b/demo/locker.js
@@ -34,6 +34,8 @@ const locker = {
         return false;
       case "zone.sponsoredArticle":
         return true;
+      case "zone.lexgoEatSponsor":
+        return true;
       default: 
         return undefined;
     }


### PR DESCRIPTION
## What does this PR do?

It adds the Sotheby's sponsorship messaging back to all stories desked to Lexgo Eat and all child sections. This was previously done with the Article Widget 1 grouping, and needed to be moved into zones since we lost that capability.

## Steps to test

1. Dowload [lexgoeat-sponsor-overrides.zip](https://github.com/mcclatchy/zones/files/12611787/lexgoeat-sponsor-overrides.zip) and unzip into your local overrides folder and make sure they are enabled.
2. Go to [any story](https://www.kentucky.com/lexgoeat/food/article279279859.html) in Lexgo Eat or any child section. 
3. The zone should appear above the story (section config already added).

## Screenshot

![image](https://github.com/mcclatchy/zones/assets/198070/1dd21019-cfed-448a-9e1f-2a48e63847d1)

