### PR TITLE
Ad tags

### DIFF
--- a/config/homepage.json
+++ b/config/homepage.json
@@ -2,42 +2,23 @@
   "zones": [
     {
       "id": "zone-community-events",
+      "vip": "#secondary-story-9",
       "type": "editorial",
-      "filters": [
-        {
-          "type": "config",
-          "name": "zone.communityEvents",
-          "value": true
-        }
-      ],
+      "filters": {
+        "zone.communityEvents": true
+      },
       "zephr": {
         "feature": "zone-community-events",
-        "dataset": [
-          {
-            "type": "config",
-            "name": "market",
-            "value": "marketInfo.domain"
-          }
-        ]
-      },
-      "placement": {
-        "type": "query",
-        "value": "#secondary-story-9"
+        "dataset": ["marketInfo.domain"]
       }
     },
     {
       "id": "zone-el-9",
-      "placement": {
-        "type": "query",
-        "value": "#secondary-story-6"
-      }
+      "vip": "#seconddary-story-6"
     },
     {
       "id": "zone-el-11",
-      "placement": {
-        "type": "query",
-        "value": "#secondary-story-10"
-      }
+      "vip": "#secondary-story-10"
     }
   ]
 }

--- a/config/section.json
+++ b/config/section.json
@@ -2,15 +2,9 @@
   "zones": [
     {
       "id": "zone-el-9",
-      "filters": [
-        {
-          "type": "subscriber",
-          "value": false
-        }
-      ],
-      "placement": {
-        "type": "query",
-        "value":  ".grid > :nth-child(14)"
+      "vip": ".grid > :nth-child(14)",
+      "filters": {
+        "subscriber": false
       }
     }
   ]

--- a/config/story.json
+++ b/config/story.json
@@ -8,12 +8,20 @@
   },
   "zones": [
     {
+      "id": "zone-el-101",
+      "targeting": {
+        "atf": true
+      }
+    },
+    {
       "id": "zone-el-1",
       "vip": ".flag",
       "position": "afterend",
       "filters": {
-        "subscriber": false,
-        "zone.sponsoredArticle": false
+        "subscriber": false
+      },
+      "targeting": {
+        "memo": "customized in the config"
       }
     },
     {

--- a/config/story.json
+++ b/config/story.json
@@ -1,5 +1,5 @@
 {
-  "base": ".story-body [id^=zone-el]",
+  "wps": ".story-body [id^=zone-el]",
   "ignore": ["zone-el-16"],
   "cadence": {
     "subscriber": 4,
@@ -8,118 +8,71 @@
   },
   "zones": [
     {
+      "id": "zone-el-1",
+      "vip": ".flag",
+      "position": "afterend",
+      "filters": {
+        "subscriber": false,
+        "zone.sponsoredArticle": false
+      }
+    },
+    {
       "id": "zone-taboola-recommendations",
-      "filters": [
-        {
-          "type": "config",
-          "name": "zone.taboolaRecommendations",
-          "value": true
-        }
-      ],
+      "after": "zone-el-101",
+      "tracking": true,
+      "filters": {
+        "zone.taboolaRecommendations": true
+      },
       "zephr": {
         "feature": "zone-taboola-recommendations",
-        "dataset": [
-          {
-            "type": "dma",
-            "name": "dma"
-          }
-        ]
-      },
-      "placement": {
-        "type": "after",
-        "value": "zone-el-101"
-      },
-      "tracking": true
+        "dataset": ["dma"]
+      }
     },
     {
       "id": "zone-si-tickets",
       "cue": 278143207,
-      "filters": [
-        {
-          "type": "config",
-          "name": "zone.siTickets",
-          "value": true
-        }
-      ],
-      "placement": {
-        "type": "after",
-        "value": "zone-el-101"
+      "after": "zone-el-101",
+      "filters": {
+        "zone.siTickets": true
       }
     },
     {
       "id": "zone-gamecocks-nav",
+      "vip": ".story-body",
       "cue": 278142507,
-      "filters": [
-        {
-          "type": "config",
-          "name": "zone.gamecocksNav",
-          "value": true
-        }
-      ],
-      "placement": {
-        "type": "query",
-        "value": ".story-body"
+      "filters": {
+        "zone.gamecocksNav": true
       }
     },
     {
       "id": "zone-sponsored-article",
       "cue": 277282728,
-      "filters": [
-        {
-          "type": "config",
-          "name": "zone.sponsoredArticle",
-          "value": true
-        }
-      ],
-      "placement": {
-        "type": "query",
-        "value": ".story-body > .header"
-      },
-      "classList": ["hidden"]
+      "vip": ".story-body > .header",
+      "classList": ["hidden"],
+      "filters": {
+        "zone.sponsoredArticle": true
+      }
     },
     {
       "id": "zone-local-news-digest",
       "tracking": true,
-      "filters": [
-        {
-          "type": "config",
-          "name": "zone.localNewsDigest",
-          "value": true
-        },
-        {
-          "type": "dma",
-          "value": true
-        }
-      ],
+      "after": "zone-el-101",
+      "classList": ["stn-player"],
+      "filters": {
+        "dma": true,
+        "zone.localNewsDigest": true
+      },
       "zephr": {
         "feature": "zone-local-news-digest",
-        "dataset": [
-          {
-            "type": "config",
-            "name": "domain",
-            "value": "marketInfo.domain"
-          }
-        ]
-      },
-      "placement": {
-        "type": "after",
-        "value": "zone-el-101"
-      },
-      "classList": ["stn-player"]
+        "dataset": ["marketInfo.domain"]
+      }
     },
     {
       "id": "zone-lexgoeat-sponsor",
+      "vip": ".story-body",
       "cue": 266575046,
-      "filters": [
-        {
-          "type": "config",
-          "name": "zone.lexgoEatSponsor",
-          "value": true
-        }
-      ],
-      "placement": {
-        "type": "query",
-        "value": ".story-body" 
+      "filters": {
+        "zone.lexgoEatSponsor": true
       }
     }
   ]

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -6,6 +6,10 @@
   min-height: 300px;
 }
 
+.digest {
+  min-height: 600px;
+}
+
 .lead-item {
   min-height: 600px;
 }

--- a/demo/homepage/index.html
+++ b/demo/homepage/index.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="en" data-pagetype="homepage">
+  <head>
+    <title>Zones homepage demo</title>
+    <link rel="icon" type="image/x-icon" href="https://www.kansascity.com/favicon.ico">
+    
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+
+    <link rel="stylesheet" href="https://storage.googleapis.com/mc-high-impact/saratoga/saratoga-1.16.15.css">
+    <link rel="stylesheet" href="/demo/demo.css">
+
+    <script type="module">
+      import locker from "../locker.js";
+      import distributeZones from "/index.js";
+
+      distributeZones(locker);
+    </script>
+  </head>
+
+  <body>
+    <!-- <div id="zone-el-1"></div> -->
+    <!-- <div id="zone-el-2"></div> -->
+    <div class="card flag"></div>
+
+    <section class="grid">
+      <article class="card lead-item"></article>
+
+      <div id="zone-el-5" class="zone two-rows"></div>
+
+      <div class="digest"></div>
+      <article id="secondary-story-2" class="card"></article>
+      <article id="secondary-story-3" class="card"></article>
+      <div class="digest"></div>
+
+      <article id="secondary-story-4" class="card"></article>
+      <article id="secondary-story-5" class="card"></article>
+      <article id="secondary-story-6" class="card"></article>
+      <article id="secondary-story-7" class="card"></article>
+      <article id="secondary-story-8" class="card"></article>
+      <article id="secondary-story-9" class="card"></article>
+
+      <div id="zone-el-6" class="zone"></div>
+
+      <div class="digest-group">
+        <div class="partner-label">
+          <span>Digest group</span>
+        </div>
+        <div class="digest"></div>
+        <div class="digest"></div>
+        <div class="digest"></div>
+      </div>
+
+      <article id="secondary-story-10" class="card"></article>
+      <article id="secondary-story-11" class="card"></article>
+
+      <div id="zone-el-8" class="zone three-columns"></div>
+
+      <div class="digest-group">
+        <div class="partner-label">
+          <span>Digest group</span>
+        </div>
+        <div class="digest"></div>
+        <div class="digest"></div>
+        <div class="digest"></div>
+      </div>
+
+      <article id="secondary-story-12" class="card"></article>
+      <article id="secondary-story-13" class="card"></article>
+      <article id="secondary-story-13" class="card"></article>
+      <article id="secondary-story-14" class="card"></article>
+      <article id="secondary-story-15" class="card"></article>
+      <article id="secondary-story-16" class="card"></article>
+
+      <div id="zone-el-15" class="zone"></div>
+
+      <article id="secondary-story-17" class="card"></article>
+      <article id="secondary-story-18" class="card"></article>
+      <article id="secondary-story-19" class="card"></article>
+    </section>
+  </body>
+</html>

--- a/demo/locker.js
+++ b/demo/locker.js
@@ -27,14 +27,16 @@ const locker = {
       case "zone.communityEvents":
         return true;
       case "zone.taboolaRecommendations":
-        return true;
+        return false;
       case "zone.siTickets":
         return false;
       case "zone.gamecocksNav":
         return false;
       case "zone.sponsoredArticle":
-        return true;
+        return false;
       case "zone.lexgoEatSponsor":
+        return false;
+      case "zone.localNewsDigest":
         return true;
       default: 
         return undefined;
@@ -44,7 +46,7 @@ const locker = {
   // user info
   user: {
     isSubscriber() {
-      return true;
+      return false;
     },
 
     isLoggedIn() {
@@ -52,7 +54,7 @@ const locker = {
     },
 
     isInDMA() {
-      return Promise.resolve(false);
+      return Promise.resolve(true);
     }
   },
 
@@ -95,7 +97,7 @@ const locker = {
   // Demo only for now
   config: {
     homepage: "/config/homepage.json",
-    section: "/config/section.json",
+    sectfront: "/config/section.json",
     story: "/config/story.json"
   }
 }

--- a/demo/locker.js
+++ b/demo/locker.js
@@ -37,7 +37,7 @@ const locker = {
       case "zone.lexgoEatSponsor":
         return false;
       case "zone.localNewsDigest":
-        return true;
+        return false;
       default: 
         return undefined;
     }
@@ -90,8 +90,18 @@ const locker = {
     }
   },
 
+  // ad logic coming from Yozoons (proposed)
   areAdsAllowed() {
     return true;
+  },
+
+  createAdTag(targeting) {
+    let tag = document.createElement("div");
+
+    tag.classList.add("ad");
+    tag.setAttribute("targeting", JSON.stringify(targeting));
+
+    return tag;
   },
 
   // Demo only for now

--- a/demo/section/index.html
+++ b/demo/section/index.html
@@ -11,7 +11,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
 
-    <link rel="stylesheet" href="https://storage.googleapis.com/mc-high-impact/saratoga/saratoga-1.16.4.css">
+    <link rel="stylesheet" href="https://storage.googleapis.com/mc-high-impact/saratoga/saratoga-1.16.15.css">
     <link rel="stylesheet" href="/demo/demo.css">
 
     <script type="module">

--- a/demo/story/index.html
+++ b/demo/story/index.html
@@ -24,13 +24,13 @@
         .catch((e) => { console.warn(e) });
 
       // Listen for the loaded event
-      window.addEventListener("zones-loaded", console.log("zones are loaded"));
+      // window.addEventListener("zones-loaded", console.log("zones are loaded"));
 
       // Listen for the intersection event
-      window.addEventListener("zone", (e) => console.log("zone showing: %s", JSON.stringify(e.detail)));
+      // window.addEventListener("zone", (e) => console.log("zone showing: %s", JSON.stringify(e.detail)));
 
       // Listen for tracking events
-      window.addEventListener("trackcustomzones", (e) => console.log("zone tracked: %s", JSON.stringify(e.detail)));
+      // window.addEventListener("trackcustomzones", (e) => console.log("zone tracked: %s", JSON.stringify(e.detail)));
 
       // Demo-only show vips
       import { getValidInsertionPoints } from "/lib/zones.js";

--- a/demo/story/index.html
+++ b/demo/story/index.html
@@ -39,6 +39,8 @@
   </head>
 
   <body>
+    <!-- <div id="zone-el-1"></div> -->
+
     <div class="card flag"></div>
 
     <article class="paper story-body">

--- a/index.js
+++ b/index.js
@@ -6,9 +6,13 @@ import * as zones from "./lib/zones.js";
 import * as config from "./lib/config.js";
 import * as story from "./lib/story.js";
 
-function distributeZones(locker) {
+async function distributeZones(locker) {
+  const subscriber = locker.user.isSubscriber();
+
   // Setup
   zones.setLocker(locker);
+  zones.setConfig("subscriber", subscriber);
+  zones.setConfig("dma", subscriber ? true : await locker.user.isInDMA());
 
   // Config files 
   if(!locker.config) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,7 +2,7 @@
  * JSON configuration support
  */
 
-import { locker, Zone, ignore, distribute } from "./zones.js";
+import * as zones from "./zones.js";
 
 /**
  * Loads a configuration file
@@ -11,8 +11,14 @@ import { locker, Zone, ignore, distribute } from "./zones.js";
  */
 
 export function load(url) {
+  const locker = zones.getLocker();
+  const template = zones.getConfig("template");
+  const subscriber = zones.getConfig("subscriber");
+  const dma = zones.getConfig("dma");
+
   return new Promise(async (resolve, reject) => {
-    let data;
+    // Make the request
+    let data = null;
     const res = await fetch(url);
 
     // Reject if file missing
@@ -29,131 +35,14 @@ export function load(url) {
       return;
     }
 
-    // Configs
-    const template = locker.pageType;
-    const subscriber = locker.user.isSubscriber();
-    const dma = subscriber ? true : await locker.user.isInDMA();
-
-    // Load WPS zones
-    if(data.base) {
-      const base = document.querySelectorAll(data.base);
-      base.forEach(ele => new Zone(ele.id));
-    }
-    
-    // Ignore these zones
-    if(data.ignore) {
-      ignore(...data.ignore);
+    // Load WPS zones by query
+    if(data.wps) {
+      let wps = document.querySelectorAll(data.wps);
+      wps.forEach(ele => new zones.Zone(ele.id));
     }
 
-    // Loop through changes
-    const zones = data.zones || [];
-    zones.forEach(config => {
-      let show = true;
-
-      // Filter check
-      if(config.filters) {
-        show = config.filters.every(f => {
-          const { type, name, value, pattern } = f;
-
-          switch(type) {
-            case "subscriber":
-              return subscriber === value;
-            case "dma":
-              return dma === value;
-            case "config":
-              const prop = locker.getConfig(name);
-
-              // Pattern will peform a Regex match on the config value
-              if(pattern) {
-                let rx = new RegExp(pattern);
-                return rx.test(prop) == value;
-              } 
-
-              // Anything else is a straight compare
-              else {
-                return prop === value;
-              } 
-          }
-        });
-      }
-
-      // Render 
-      if(show) {
-        const zone = new Zone(config.id);
-
-        // Zephr connection
-        if(config.zephr) {
-          const { feature, dataset } = config.zephr;
-
-          if(dataset) {
-            dataset.forEach(d => {
-              const {type, name, value} = d;
-
-              switch(type) {
-                case "subscriber":
-                  zone.dataset[name] = subscriber;
-                  break;
-                case "dma":
-                  zone.dataset[name] = dma;
-                  break;
-                case "config":
-                  zone.dataset[name] = locker.getConfig(value);
-                  break;
-                default:
-                  zone.dataset[name] = value;
-              }
-            });
-          }
-
-          zone.zephr(feature);
-        }
-
-        // CUE connection
-        if(config.cue) {
-          zone.cue(config.cue);
-        }
-
-        // Add classes
-        if(config.classList) {
-          zone.classList.add(...config.classList)
-        }
-
-        // Add type
-        if(config.type) {
-          zone.dataset.type = config.type;
-        }
-
-        // Add tracking
-        if(config.tracking) {
-          zone.tracking = true;
-        }
-
-        // Placement
-        if(config.placement) {
-          const {type, value} = config.placement;
-
-          switch(type) {
-            case "query":
-              zone.vip = document.querySelector(value);
-              break
-            case "before":
-              zone.before(value);
-              break;
-            case "after":
-              zone.after(value);
-              break;
-            case "remove":
-              zone.remove();
-              break;
-            default:
-              zone.vip = value;
-          }
-        }
-      }
-    });
-
-    // Story page cadence distribution
-    if(locker.pageType == "story") {
+    // Generate story zones
+    if(data.cadence && zones.isStoryPage()) {
       let cadence;
 
       switch(true) {
@@ -167,9 +56,100 @@ export function load(url) {
           cadence = data.cadence.standard;
       }
 
-      distribute(cadence);
+      zones.setCadence(cadence);
+      zones.createStoryZones();
     }
 
+    // Ignore these WPS zones
+    if(Array.isArray(data.ignore)) {
+      zones.ignore(...data.ignore);
+    }
+
+    // Loop through zones
+    const set = new Set(data.zones);
+
+    set.forEach( config => {
+      const { 
+        id, 
+        filters = [], 
+        vip = undefined, 
+        position = "beforebegin",
+        before = undefined, 
+        after = undefined,
+        classList = [],
+        type = "ad",
+        tracking = false,
+        cue,
+        zephr
+      } = config;
+
+      // Make the zone 
+      if(check(filters)) {
+        const zone = new zones.Zone(id);
+
+        // Placement options
+        if(vip) {
+          zone.vip = document.querySelector(config.vip);
+        } 
+        else if(before) {
+          zone.before(config.before);
+        }
+        else if(after) {
+          zone.after(config.after);
+        } 
+
+        // Pass some configs straight through
+        zone.position = position;
+        zone.classList.add(...classList)
+        zone.type = type;
+        zone.tracking = tracking;
+
+        // CUE connection
+        if(cue) {
+          zone.cue(config.cue);
+        }
+
+        // Zephr connection
+        if(zephr) {
+          const { feature, dataset } = config.zephr;
+
+          if(Array.isArray(dataset)) {
+            dataset.forEach(c => {
+              zone.dataset[c] = zones.getConfig(c);
+            });
+          }
+
+          zone.zephr(feature);
+        }
+      }
+    });
+
     resolve();
+  });
+}
+
+/*
+ * Checks configs
+ * @param filters {object} a set of section configs or segments 
+ * @returns {boolean}
+ */
+
+function check(filters) {
+  const keys = Object.keys(filters || []); 
+
+  if(!keys.length) {
+    return true;
+  }
+
+  return keys.every(key => {
+    let value = filters[key];
+    let config = zones.getConfig(key);
+
+    if(typeof value == "boolean") {
+      return config == value;
+    } else {
+      let rx = new RegExp(value, "i");
+      return rx.test(config);
+    }
   });
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -80,14 +80,18 @@ export function load(url) {
         type = "ad",
         tracking = false,
         cue,
-        zephr
+        zephr,
+        targeting
       } = config;
 
       // Make the zone 
       if(check(filters)) {
         const zone = new zones.Zone(id);
 
-        // Placement options
+        /*
+         * Placement options
+         */
+
         if(vip) {
           zone.vip = document.querySelector(config.vip);
         } 
@@ -98,20 +102,22 @@ export function load(url) {
           zone.after(config.after);
         } 
 
-        // Pass some configs straight through
-        zone.position = position;
-        zone.classList.add(...classList)
-        zone.type = type;
-        zone.tracking = tracking;
+        /*
+         * Output options
+         */
+
+        if(targeting) {
+          zone.gam(targeting);
+        }
 
         // CUE connection
-        if(cue) {
-          zone.cue(config.cue);
+        else if(cue) {
+          zone.cue(cue);
         }
 
         // Zephr connection
-        if(zephr) {
-          const { feature, dataset } = config.zephr;
+        else if(zephr) {
+          const { feature, dataset } = zephr;
 
           if(Array.isArray(dataset)) {
             dataset.forEach(c => {
@@ -121,6 +127,15 @@ export function load(url) {
 
           zone.zephr(feature);
         }
+
+        /*
+         * Remaining configs
+         */
+
+        zone.position = position;
+        zone.classList.add(...classList)
+        zone.type = type;
+        zone.tracking = tracking;
       }
     });
 

--- a/lib/zones.js
+++ b/lib/zones.js
@@ -3,13 +3,12 @@
  */
 
 // Internals
+let locker, cadence;
 let map = new Map();
-let fragment = new DocumentFragment();
-let loadObserver = new IntersectionObserver(handleLoad, { rootMargin: "500px" });
-let trackingObserver = new IntersectionObserver(handleTracking, { threshold: 0.25 });
-
-// Locker
-export let locker;
+const configs = new Map();
+const fragment = new DocumentFragment();
+const loadObserver = new IntersectionObserver(handleLoad, { rootMargin: "500px" });
+const trackingObserver = new IntersectionObserver(handleTracking, { threshold: 0.25 });
 
 // Changes map
 export const changes = new Map();
@@ -24,13 +23,14 @@ export class Zone {
    * Zone constructor
    */
 
-  constructor(id, vip = null) {
+  constructor(id, vip = null, position = "beforebegin") {
     if(!id) {
       throw new Error("zone id is required");
     }
 
     this.id = id;
     this.vip = vip;
+    this.position = position;
   }
 
   /*
@@ -92,7 +92,7 @@ export class Zone {
   async zephr(feature) {
     const market = locker.getConfig("marketInfo.domain");
     const endpoint = `https://mcclatchy-${market}.cdn.zephr.com/zephr/decision-engine`;
-    const body = JSON.stringify({ "sdkFeatureSlug": feature, ...this.element.dataset });
+    const body = JSON.stringify({ "sdkFeatureSlug": feature, ...this.dataset });
 
     const req = await fetch(endpoint, {
       method: "POST",
@@ -138,10 +138,11 @@ export class Zone {
   /*
    * Injects this zone
    * @param ele {element} the injection point
-   * @param loc {string} the placement relative to the injection point
+   * @param position {string} the placement relative to the injection point
+   * @param vip {element} the insertion point for the zone
    */
 
-  inject(loc = "beforebegin") {
+  inject(position = this.position, vip = this.vip) {
     let err = false;
     
     // Error checks
@@ -161,9 +162,9 @@ export class Zone {
       this.remove();
       this.log(err);
     } else {
-      this.element.dataset.distributed = true;
-      this.vip.insertAdjacentElement(loc, this.element);
-      this.log(this.msg || "zone moved into new location");
+      vip.insertAdjacentElement(position, this.element);
+      this.dataset.distributed = true;
+      this.log(this.msg || "zone created");
 
       // Observer for performance team
       loadObserver.observe(this.element);
@@ -184,7 +185,7 @@ export class Zone {
   }
 
   /*
-   * Insert this zone before another
+   * Insert this zone before another (story pages)
    * @param referenceId {string} the id of the reference zone
    */
 
@@ -202,7 +203,7 @@ export class Zone {
   }
 
   /*
-   * Insert this zone after another
+   * Insert this zone after another (story pages)
    * @param referenceId {string} the id of the reference zone
    */
 
@@ -231,6 +232,7 @@ export class Zone {
 
 /*
  * Gets the locker for external use
+ * @returns {object} the locker
  */
 
 export function getLocker() {
@@ -247,8 +249,61 @@ export function setLocker(obj) {
 }
 
 /*
+ * Gets a config stored locally
+ * @returns {(boolean|string)} the value of the stored config
+ */
+
+export function getConfig(key) {
+  if(configs.has(key)) {
+    return configs.get(key);
+  } else {
+    const val = locker.getConfig(key);
+    configs.set(key, val);
+    return val;
+  }
+}
+
+/*
+ * Stores a config locally
+ * @param key {string} the key for the config
+ * @apram value {(boolean|string)} the value for the config
+ */
+
+export function setConfig(key, value) {
+  configs.set(key, value);
+}
+
+/*
+ * Checks to see if on a story page
+ * @returns {boolean}
+ */
+
+export function isStoryPage() {
+  return locker.pageType == "story";
+}
+
+/* 
+ * Gets the cadence for story pages
+ * @returns {integer} the cadence
+ */
+
+export function getCadence() {
+  return parseInt(cadence) || 3;
+}
+
+/*
+ * Sets the cadence
+ * @param int {integer} the number to set
+ */
+
+export function setCadence(int) {
+  cadence = parseInt(int);
+}
+
+/*
  * Gets a zone
  * @param id {string} the id for the zone
+ * @returns {object} a zone
  */
 
 export function get(id) {
@@ -327,7 +382,6 @@ export function log(id, msg) {
   changes.set(id, msg);
 }
 
-
 /*
  * Tracks a feature flag in Amplitude
  * @param key {string} the key for the feature
@@ -384,14 +438,28 @@ export function getValidInsertionPoints() {
 }
 
 /*
+ * Creates a dynamic number of story zones
+ * @param cadence {integer} the cadence
+ */
+
+export function createStoryZones() {
+  const vips = getValidInsertionPoints();
+  const total = Math.floor(vips.length / cadence);
+
+  for(let i = 1; i <= total; i++) {
+    new Zone(`zone-el-${100 + i}`);
+  }
+}
+
+/*
  * Distributes zones generically using vips
  * @param map {Map} the map to alter
  * @param tick {integer} the cadence
  */
 
-export function distribute(tick = 4) {
+export function distribute() {
   const vips = getValidInsertionPoints();
-  const cadence = tick;
+  let tick = cadence;
 
   map.forEach(zone => {
     if(!zone.vip) {
@@ -407,6 +475,10 @@ export function distribute(tick = 4) {
  */
 
 export function render() {
+  // Distribute story zones
+  if(isStoryPage()) distribute();
+
+  // Inject
   map.forEach(zone => zone.inject());
   window.dispatchEvent(new Event("zones-loaded"));
 }

--- a/lib/zones.js
+++ b/lib/zones.js
@@ -2,9 +2,9 @@
  * Zones
  */
 
-// Internals
 let locker, cadence;
 let map = new Map();
+
 const configs = new Map();
 const fragment = new DocumentFragment();
 const loadObserver = new IntersectionObserver(handleLoad, { rootMargin: "500px" });
@@ -23,14 +23,13 @@ export class Zone {
    * Zone constructor
    */
 
-  constructor(id, vip = null, position = "beforebegin") {
+  constructor(id, vip = null) {
     if(!id) {
       throw new Error("zone id is required");
     }
 
     this.id = id;
     this.vip = vip;
-    this.position = position;
   }
 
   /*
@@ -51,6 +50,7 @@ export class Zone {
 
     this.element = zone;
     this.element.classList.add("zone");
+    this.element.fragment = new DocumentFragment();
 
     // Add this zone to the map
     map.set(val, this);
@@ -108,7 +108,7 @@ export class Zone {
     // Create the range including script tags
     if(payload) {
       const range = document.createRange().createContextualFragment(payload);
-      this.element.append(range);
+      this.element.fragment.append(range);
     } else {
       this.log("Zephr paylod was empty");
     }
@@ -129,15 +129,30 @@ export class Zone {
 
     if(payload) {
       const range = document.createRange().createContextualFragment(payload);
-      this.element.append(range);
+      this.element.fragment.append(range);
     } else {
       this.log("CUE payload was empty");
     }
   }
 
   /*
+   * GAM ad functionality
+   * @param targeting {object} the targeting string for the ad
+   */
+
+  async gam(targeting) {
+    const defaults = {
+      "memo": "default"
+    }
+    
+    const payload = {...defaults, ...targeting};
+    const tag = locker.createAdTag(payload);
+
+    this.element.fragment.append(tag);
+  }
+
+  /*
    * Injects this zone
-   * @param ele {element} the injection point
    * @param position {string} the placement relative to the injection point
    * @param vip {element} the insertion point for the zone
    */
@@ -162,7 +177,18 @@ export class Zone {
       this.remove();
       this.log(err);
     } else {
-      vip.insertAdjacentElement(position, this.element);
+      // Insert the element
+      vip.insertAdjacentElement(position || "beforebegin", this.element);
+
+      // If no fragment, make it an ad
+      if(this.element.fragment.childElementCount == 0) {
+        this.gam({ 
+          atf: false,
+          memo: "default" 
+        });
+      }
+
+      // Messaging
       this.dataset.distributed = true;
       this.log(this.msg || "zone created");
 
@@ -447,7 +473,7 @@ export function createStoryZones() {
   const total = Math.floor(vips.length / cadence);
 
   for(let i = 1; i <= total; i++) {
-    new Zone(`zone-el-${100 + i}`);
+    const zone = new Zone(`zone-el-${100 + i}`);
   }
 }
 
@@ -490,10 +516,16 @@ export function render() {
 function handleLoad(entries, observer) {
   entries.forEach((entry) => {
     if(entry.isIntersecting) {
+      let e = entry.target;
+
+      // Move the fragment into position
+      // console.log(e.id, e.fragment);
+      e.append(e.fragment);
+
       // Build the load event
       const intersectionEvent = new CustomEvent("zone", {
         detail: {
-          id: entry.target.id
+          id: e.id
         }
       });
 
@@ -501,7 +533,7 @@ function handleLoad(entries, observer) {
       window.dispatchEvent(intersectionEvent);
 
       // Only do this once
-      loadObserver.unobserve(entry.target);
+      loadObserver.unobserve(e);
     }
   });
 }


### PR DESCRIPTION
## What does this PR do?

It adds new functionality to auto-generate centennial zones (`zone-el-100+`) inside the story body using the valid insertion point concept. This is a departure from WPS providing zones that we simply move. Zones sent via WPS will still be used while they are there, but this change will allow us to start removing them in the WPS logic.

It also adds a very basic `createAdTag()` function to the demo locker for testing. This function will be written by the Performance Team and provided in our locker or via an ads API. Joe W has confirmed this is a good setup, and will be starting the ad API work when he can get to it.

## What to test

In addition to automatically creating the centennial zones, we can overload their GAM payloads in the config file. Play with that a bit and make sure it feels good to you both. A fun byproduct of the filtering concept means we can change the payload for specific segments, but use the default elsewhere.

### Notes

This code was written after the [config changes](https://github.com/mcclatchy/zones/pull/19), so should probably be merged after that PR review is complete.