### PR TITLE
New config structure

### DIFF
--- a/config/homepage.json
+++ b/config/homepage.json
@@ -13,7 +13,6 @@
     {
       "id": "zone-community-events",
       "vip": "#secondary-story-9",
-      "type": "editorial",
       "filters": {
         "zone.communityEvents": true
       },
@@ -25,7 +24,6 @@
     {
       "id": "zone-events-calendar",
       "vip": "#secondary-story-7",
-      "type": "editorial",
       "classList": ["package", "paper", "two-columns", "two-rows"],
       "filters": {
         "zone.eventsCalendar": true

--- a/config/homepage.json
+++ b/config/homepage.json
@@ -26,7 +26,7 @@
       "vip": "#secondary-story-7",
       "classList": ["package", "paper", "two-columns", "two-rows"],
       "filters": {
-        "zone.eventsCalendar": true
+        "zone-events-calendar": true
       },
       "zephr": {
         "feature": "zone-events-calendar",

--- a/config/homepage.json
+++ b/config/homepage.json
@@ -1,6 +1,16 @@
 {
   "zones": [
     {
+      "id": "zone-el-9",
+      "vip": "#secondary-story-6",
+      "type": "ad"
+    },
+    {
+      "id": "zone-el-11",
+      "vip": "#secondary-story-10",
+      "type": "ad"
+    },
+    {
       "id": "zone-community-events",
       "vip": "#secondary-story-9",
       "type": "editorial",
@@ -13,12 +23,27 @@
       }
     },
     {
-      "id": "zone-el-9",
-      "vip": "#seconddary-story-6"
+      "id": "zone-events-calendar",
+      "vip": "#secondary-story-7",
+      "type": "editorial",
+      "classList": ["package", "paper", "two-columns", "two-rows"],
+      "filters": {
+        "zone.eventsCalendar": true
+      },
+      "zephr": {
+        "feature": "zone-events-calendar",
+        "dataset": ["marketInfo.domain"]
+      }
     },
     {
-      "id": "zone-el-11",
-      "vip": "#secondary-story-10"
+      "id": "zone-editor-picks",
+      "vip": "#secondary-story-3",
+      "cue": 280305494,
+      "classList": ["three-columns"],
+      "filters": {
+        "subscriber": true,
+        "zone.editorPicks": true
+      }
     }
   ]
 }

--- a/config/section.json
+++ b/config/section.json
@@ -3,6 +3,7 @@
     {
       "id": "zone-el-9",
       "vip": ".grid > :nth-child(14)",
+      "type": "ad",
       "filters": {
         "subscriber": false
       }

--- a/config/story.json
+++ b/config/story.json
@@ -8,6 +8,11 @@
   },
   "zones": [
     {
+      "id": "zone-el-102",
+      "cue": 280305494,
+      "loading": "lazy"
+    },
+    {
       "id": "zone-el-101",
       "targeting": {
         "pkg": "b"

--- a/config/story.json
+++ b/config/story.json
@@ -10,7 +10,7 @@
     {
       "id": "zone-el-101",
       "targeting": {
-        "atf": true
+        "pkg": "b"
       }
     },
     {
@@ -21,7 +21,7 @@
         "subscriber": false
       },
       "targeting": {
-        "memo": "customized in the config"
+        "atf": "y"
       }
     },
     {

--- a/config/story.json
+++ b/config/story.json
@@ -8,28 +8,6 @@
   },
   "zones": [
     {
-      "id": "zone-el-102",
-      "cue": 280305494,
-      "loading": "lazy"
-    },
-    {
-      "id": "zone-el-101",
-      "targeting": {
-        "pkg": "b"
-      }
-    },
-    {
-      "id": "zone-el-1",
-      "vip": ".flag",
-      "position": "afterend",
-      "filters": {
-        "subscriber": false
-      },
-      "targeting": {
-        "atf": "y"
-      }
-    },
-    {
       "id": "zone-taboola-recommendations",
       "after": "zone-el-101",
       "tracking": true,
@@ -43,8 +21,8 @@
     },
     {
       "id": "zone-si-tickets",
-      "cue": 278143207,
       "after": "zone-el-101",
+      "cue": 278143207,
       "filters": {
         "zone.siTickets": true
       }
@@ -59,26 +37,11 @@
     },
     {
       "id": "zone-sponsored-article",
-      "cue": 277282728,
       "vip": ".story-body > .header",
+      "cue": 277282728,
       "classList": ["hidden"],
       "filters": {
         "zone.sponsoredArticle": true
-      }
-    },
-    {
-      "id": "zone-local-news-digest",
-      "tracking": true,
-      "after": "zone-el-101",
-      "classList": ["stn-player"],
-      "style": "max-width: var(--section-width); min-height: 300px; background-color: purple",
-      "filters": {
-        "dma": true,
-        "zone.localNewsDigest": true
-      },
-      "zephr": {
-        "feature": "zone-local-news-digest",
-        "dataset": ["marketInfo.domain"]
       }
     },
     {

--- a/config/story.json
+++ b/config/story.json
@@ -71,6 +71,7 @@
       "tracking": true,
       "after": "zone-el-101",
       "classList": ["stn-player"],
+      "style": "max-width: var(--section-width); min-height: 300px; background-color: purple",
       "filters": {
         "dma": true,
         "zone.localNewsDigest": true

--- a/demo/ads.js
+++ b/demo/ads.js
@@ -1,0 +1,12 @@
+/*
+ * Proposed ads API
+ */
+
+export function createAdTag(targeting) {
+  let tag = document.createElement("div");
+
+  tag.classList.add("ad");
+  tag.setAttribute("targeting", JSON.stringify(targeting));
+
+  return tag;
+}

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -44,6 +44,10 @@
   font: bold 1rem var(--sans);
 }
 
+[data-type="ad"]:before {
+  padding: 0 15px;
+}
+
 /*
  * Story stuff
  */

--- a/demo/homepage/index.html
+++ b/demo/homepage/index.html
@@ -11,7 +11,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
 
-    <link rel="stylesheet" href="https://storage.googleapis.com/mc-high-impact/saratoga/saratoga-1.16.15.css">
+    <link rel="stylesheet" href="/demo/saratoga.css">
     <link rel="stylesheet" href="/demo/demo.css">
 
     <script type="module">
@@ -23,7 +23,7 @@
   </head>
 
   <body>
-    <!-- <div id="zone-el-1"></div> -->
+    <div id="zone-el-1"></div>
     <!-- <div id="zone-el-2"></div> -->
     <div class="card flag"></div>
 

--- a/demo/locker.js
+++ b/demo/locker.js
@@ -16,30 +16,32 @@ const locker = {
   // generic pageInfo getter
   getConfig(key) {
     switch(key) {
-      case "domainName":
-        return "www.kansascity.com";
       case "articleCredit":
         return "The Kansas City Star";
+      case "domainName":
+        return "www.kansascity.com";
       case "marketInfo.domain":
         return "miamiherald";
       case "marketInfo.taxonomy":
         return "News/Sports//";
-      case "zone.moneycom":
-        return false;
       case "zone.communityEvents":
-        return true;
-      case "zone.taboolaRecommendations":
         return false;
-      case "zone.siTickets":
+      case "zone.editorPicks":
+        return false;
+      case "zone.eventsCalendar":
         return false;
       case "zone.gamecocksNav":
         return false;
-      case "zone.sponsoredArticle":
-        return false;
       case "zone.lexgoEatSponsor":
-        return false;
+        return true;
       case "zone.localNewsDigest":
         return true;
+      case "zone.siTickets":
+        return false;
+      case "zone.sponsoredArticle":
+        return true;
+      case "zone.taboolaRecommendations":
+        return false;
       default: 
         return undefined;
     }
@@ -48,7 +50,7 @@ const locker = {
   // user info
   user: {
     isSubscriber() {
-      return false;
+      return true;
     },
 
     isLoggedIn() {

--- a/demo/locker.js
+++ b/demo/locker.js
@@ -56,7 +56,7 @@ const locker = {
     },
 
     isInDMA() {
-      return Promise.resolve(true);
+      return Promise.resolve(false);
     }
   },
 

--- a/demo/locker.js
+++ b/demo/locker.js
@@ -2,6 +2,8 @@
  * This is a fake Yozons locker for development
  */
 
+import * as ads from "./ads.js";
+
 const locker = {
   pageType: document.documentElement.dataset.pagetype,
   template: document.documentElement.dataset.template,
@@ -58,6 +60,10 @@ const locker = {
     }
   },
 
+  areAdsAllowed() {
+    return true;
+  },
+
   // utility for timing
   executeWhenDOMReady(callback, state = document.readyState) {
     if (callback && typeof callback === 'function') {
@@ -72,10 +78,10 @@ const locker = {
   },
 
   // mimic locker functionality
-  getYozonsLocker(val) {
+  getYozonsLocker(key) {
     window.mi = window.mi || {};
 
-    switch(val) {
+    switch(key) {
       case "zones":
         window.mi.zones = window.mi.zones || {};
         return window.mi.zones;
@@ -90,18 +96,12 @@ const locker = {
     }
   },
 
-  // ad logic coming from Yozoons (proposed)
-  areAdsAllowed() {
-    return true;
-  },
-
-  createAdTag(targeting) {
-    let tag = document.createElement("div");
-
-    tag.classList.add("ad");
-    tag.setAttribute("targeting", JSON.stringify(targeting));
-
-    return tag;
+  // API functionality (proposed)
+  getAPI(key) {
+    switch(key) {
+      case "ads":
+        return ads;
+    }
   },
 
   // Demo only for now

--- a/demo/locker.js
+++ b/demo/locker.js
@@ -39,7 +39,7 @@ const locker = {
       case "zone.lexgoEatSponsor":
         return false;
       case "zone.localNewsDigest":
-        return false;
+        return true;
       default: 
         return undefined;
     }
@@ -56,7 +56,7 @@ const locker = {
     },
 
     isInDMA() {
-      return Promise.resolve(false);
+      return Promise.resolve(true);
     }
   },
 

--- a/demo/locker.js
+++ b/demo/locker.js
@@ -28,7 +28,7 @@ const locker = {
         return false;
       case "zone.editorPicks":
         return false;
-      case "zone.eventsCalendar":
+      case "zone-events-calendar":
         return false;
       case "zone.gamecocksNav":
         return false;

--- a/demo/saratoga.css
+++ b/demo/saratoga.css
@@ -3,78 +3,68 @@
  * Default parameters
  */
 :root {
-  /* Fonts */
-  font: 16px/1.5rem var(--serif);
-  --sans: "Noto Sans", sans-serif;
-  --serif: "Noto Serif", serif;
+  /* Typography */
+  font: var(--font-base)/1.5rem var(--serif);
+  --font-base: 18px;
+  --sans: "Noto Sans", Verdana, sans-serif;
+  --serif: "Noto Serif", Georgia, serif;
   --premium-serif: "DM Serif Display", serif;
+  --h1: calc(var(--font-base)*1.875);
+  --h2: calc(var(--font-base)*1.5);
+  --h3: calc(var(--font-base)*1.1);
+  --h4: var(--font-base);
   /* Spacing and alignment */
-  --gap: 30px;
-  --half-gap: calc(var(--gap) / 2);
-  --spread: 10px;
-  --page-padding: 15px;
+  --space: 20px;
+  --space-sm: calc(var(--space)/2);
+  --space-lg: calc(var(--space)*3);
+  --grid-row-gap: var(--space);
+  --grid-column-gap: var(--space);
+  --page-padding: var(--space);
   --section-width: 1140px;
   --story-width: 728px;
+  --story-media-width: var(--story-width);
+  --story-embed-width: var(--story-width);
   --columns: repeat(auto-fit, minmax(300px, 1fr));
   /* Colors */
-  --black: #01101c;
-  --gray: #707070;
-  --impact: #373737;
-  --promo: #31409F;
-  --premium-bc: #00223e;
-  --premium-tc: white;
-  --premium-impact: #ffd71a;
-  --body-background: #f4f4f4;
-  --ad-background: #e6e6e6;
-  /* Link and button defaults */
-  --lc: inherit;
-  --ld: none;
-  --bc: white;
-  --bbc: var(--impact);
-  /* Paper box shadow */
-  --paper-shadow:
-    0 1px 2px 0 rgba(0, 0, 0, .2),
-    0 1px 5px 0 rgba(0, 0, 0, .13);
-  /**
-   * Header properties available
-   *
-   * --hf: header family
-   * --hw: header weigth
-   * --ht: header transform
-   * --hl: header leading
-   * --hc: header color
-   * --hs: header size
-   */
-  /**
-   * Text properties available
-   *
-   * --tc: text color
-   * --fc: fill color (inline svg)
-   */
-  /**
-   * Link properties available
-   *
-   * --lc: link color
-   * --ld: link decoration
-   * --lhc: link hover color
-   * --lhd: link hover decoration
-   */
-  /**
-   * Button properties available
-   *
-   * --bc: button color
-   * --bbc: button background color
-   */
+  --black: #241f21;
+  --gray: #f5f7fa;
+  --darkgray: #4F5864;
+  --white: #ffffff;
+  --light-brown: #f7efe0;
+  --dark-brown: #a4906e;
+  --light-orange: #fee4d0;
+  --dark-orange: #e49162;
+  --light-green: #ebf7da;
+  --dark-green: #9ea472;
+  --light-blue: #c3d8e4;
+  --dark-blue: #273f57;
+  /* Generic color properties */
+  --background-color: var(--gray);
+  --text-color: #1F2933;
+  --secondary-text-color: var(--darkgray);
+  --media-background-color: #e9ecf0;
+  /* Subscriber color properties */
+  --sub-blue: #00223e;
+  --sub-text-color: var(--white);
+  --sub-secondary-text-color: #ffd71a;
+  /* Link properties */
+  --link-color: #132DAD;
+  --link-decoration: none;
+  /* Paper properties */
+  --paper-color: var(--white);
+  --paper-shadow: none;
+  /* Deprecated. Used in older custom elements. */
+  --gap: var(--space);
+  --spread: var(--space-sm);
+  --premium-bc: var(--sub-blue);
+  --premium-tc: var(--sub-text-color);
+  --premium-impact: var(--sub-secondary-text-color);
 }
 
-@media (min-width: 768px) {
-  :root {
-    --page-padding: 30px;
-  }
-}
 body {
   margin: 0;
-  background-color: var(--body-background);
+  background-color: var(--background-color);
+  color: var(--text-color);
 }
 
 body.freeze {
@@ -90,27 +80,27 @@ h3, .h3,
 h4, .h4,
 h5, .h5,
 h6, .h6 {
-  font-family: var(--hf, inherit);
-  font-weight: var(--hw, bold);
-  text-transform: var(--ht, none);
-  line-height: var(--hl, 1.2em);
-  color: var(--hc, var(--tc));
+  font-family: var(--header-family, inherit);
+  font-weight: var(--header-weight, bold);
+  text-transform: var(--header-transform, none);
+  line-height: var(--header-leading, 1.3em);
+  --link-color: var(--text-color);
 }
 
 h1, .h1 {
-  font-size: var(--hs, 1.875rem);
+  font-size: var(--h1);
 }
 
 h2, .h2 {
-  font-size: var(--hs, 1.5rem);
+  font-size: var(--h2);
 }
 
 h3, .h3 {
-  font-size: var(--hs, 1.2rem);
+  font-size: var(--h3);
 }
 
 h4, .h4 {
-  font-size: var(--hs, 1rem);
+  font-size: var(--h4);
 }
 
 h5, .h5 {
@@ -122,13 +112,13 @@ h6, .h6 {
 }
 
 a {
-  color: var(--lc);
-  text-decoration: var(--ld);
+  color: var(--link-color);
+  text-decoration: var(--link-decoration);
 }
 
 a:hover {
-  color: var(--lhc, var(--lc));
-  text-decoration: var(--lhd, var(--ld));
+  color: var(--link-hover-color, var(--link-color));
+  text-decoration: var(--link-hover-decoration, var(--link-decoration));
 }
 
 ul, ol {
@@ -140,24 +130,15 @@ li {
 }
 
 .kicker {
-  display: inline-block;
-  padding: 5px 8px;
-  font-weight: normal;
-  color: var(--tc, var(--black));
-  border: 1px solid var(--tc, var(--black));
-  border-radius: 2px;
   text-transform: uppercase;
-  --ld: none;
-  --lhd: none;
-  --lc: var(--tc);
-  --lhc: var(--tc);
+  font-size: 0.6rem;
 }
 
 time, .time, .byline {
   display: inline-block;
-  text-transform: uppercase;
-  color: var(--tc, var(--gray));
+  color: var(--secondary-text-color);
   font: 0.75rem/1.1em var(--sans);
+  text-transform: uppercase;
 }
 
 .byline a {
@@ -170,121 +151,44 @@ time, .time, .byline {
 }
 
 summary, .summary {
-  font: 0.875rem var(--sans);
+  font: 0.75rem var(--sans);
 }
 
-.label {
+.label, .label .h5 {
+  font: bold 14px/1em var(--sans);
+  text-transform: uppercase;
+  color: var(--secondary-text-color);
   margin: 0;
-  display: grid;
-  place-items: center;
-  --ld: none;
-}
-
-.label > * {
-  margin: 0;
-  padding: 5px 10px;
-  color: var(--bc, white);
-  background-color: var(--bbc, var(--impact));
-  font: bold 0.875rem var(--sans);
-  line-height: 1em;
-}
-
-.label.sticky {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  z-index: 2;
 }
 
 .more-link {
   display: inline-block;
   justify-self: end;
   font: 700 0.75rem/1em var(--sans);
-  text-transform: uppercase;
-  color: var(--tc, var(--gray));
+  color: var(--more-link-color, var(--link-color));
   text-decoration: none;
+  text-transform: uppercase;
 }
 
 .more-link:hover {
-  color: var(--tc, var(--gray));
   text-decoration: none;
 }
 
 .more-link:after {
   content: "➔";
   display: inline-block;
-  transform: translateY(-0.05em) translateX(4px);
-  transition: transform 0.6s ease;
-}
-
-.more-link:hover:after {
-  transform: translateY(-0.05em) translateX(8px);
 }
 
 .dateline {
   display: block;
   font: italic 0.875rem var(--sans);
   text-transform: uppercase;
-  color: var(--tc, #757575);
+  color: var(--secondary-text-color);
 }
 
 hr {
   align-self: stretch;
-  border: 0.5px solid var(--tc, #707070);
-}
-
-/**
- * Color schemes
- */
-.impact,
-.promo,
-.promo-light,
-.disabled,
-[disabled] {
-  background-color: var(--impact);
-  --paper-color: var(--impact);
-  --tc: white;
-  --fc: white;
-  --bc: white;
-  --hc: white;
-  --lhc: white;
-  --bbc: var(--impact);
-}
-
-.impact .button,
-.impact .label {
-  --bc: var(--impact);
-  --bbc: white;
-}
-
-.promo {
-  background-color: var(--promo);
-  --paper-color: var(--promo);
-  --bbc: var(--promo);
-}
-
-.promo .button,
-.promo .label {
-  --bc: var(--promo);
-  --bbc: white;
-}
-
-.promo-light {
-  background-color: #5169B8;
-  --paper-color: #5169B8;
-  --bbc: #5169B8;
-}
-
-.promo-light .button,
-.promo-light .label {
-  --bc: #5169B8;
-  --bbc: white;
-}
-
-.disabled, [disabled] {
-  --paper-color: #757575;
-  cursor: not-allowed;
+  border: 0.5px solid var(--secondary-text-color);
 }
 
 /**
@@ -300,12 +204,15 @@ hr {
   text-align: center;
   text-transform: uppercase;
   text-decoration: none;
-  color: var(--bc);
-  background-color: var(--bbc);
+  color: var(--button-color, var(--paper-color));
+  background-color: var(--button-background-color, var(--text-color));
   border: 1px solid transparent;
   cursor: pointer;
-  --lhc: var(--bc);
-  --lhd: none;
+}
+
+.button:hover {
+  text-decoration: none;
+  color: var(--button-hover-color, var(--paper-color));
 }
 
 .button.big {
@@ -314,21 +221,46 @@ hr {
 
 .button.text,
 .button.ghost {
-  color: var(--bbc);
+  border: 1px solid var(--text-color);
   background-color: transparent;
-  border: 1px solid var(--bbc);
+  color: var(--text-color);
 }
 
 .button.text {
   border: none;
 }
 
-.button.pill {
-  border-radius: 1.5em;
-}
-
 .button > img {
   display: block;
+}
+
+/**
+ * Color schemes
+ */
+.impact, .in-depth {
+  --paper-color: var(--impact-color, var(--black));
+  --text-color: var(--impact-text-color, var(--white));
+  --secondary-text-color: var(--impact-text-color, var(--white));
+  --fill-color: var(--impact-text-color, var(--white));
+}
+
+.promo {
+  --paper-color: var(--promo-color, var(--dark-blue));
+  --text-color: var(--promo-text-color, var(--white));
+  --secondary-text-color: var(--promo-text-color, var(--white));
+  --fill-color: var(--impact-text-color, var(--white));
+}
+
+.subonly {
+  --paper-color: var(--sub-blue);
+  --text-color: var(--sub-text-color);
+  --secondary-text-color: var(--sub-secondary-text-color);
+  --fill-color: var(--impact-text-color, var(--white));
+}
+
+.disabled, [disabled] {
+  --paper-color: var(--gray);
+  pointer-events: none;
 }
 
 /**
@@ -339,7 +271,7 @@ form, .checkbox-group {
   grid-template-columns: 1fr;
   grid-gap: 30px;
   text-align: left;
-  color: var(--tc);
+  color: var(--text-color);
 }
 
 .checkbox-group {
@@ -356,58 +288,53 @@ form > *, .checkbox-group > * {
 }
 
 form.paper {
-  padding: calc(var(--gap) / 2);
+  padding: var(--space-sm);
 }
 
 label {
   position: relative;
+  display: block;
   font: 700 0.875rem var(--sans);
   line-height: 1.5;
-  display: block;
 }
 
 label.checkbox {
   display: grid;
   grid-template-columns: min-content auto;
   grid-gap: 8px;
-  align-items: start;
+  align-items: center;
   font-weight: 400;
   cursor: pointer;
-}
-
-label.checkbox input {
-  margin-top: 0.25em;
 }
 
 label ~ input,
 label ~ select,
 label ~ .select,
-label ~ textarea,
 label input,
 label select,
-label .select,
-label textarea {
-  margin-top: 10px;
+label .select {
+  margin-top: var(--space-xs);
 }
 
 label small,
 label + small {
   display: block;
-  font: 400 0.875rem var(--sans);
-  color: var(--text-color, #707070);
   margin-top: 2px;
+  font: 400 0.875rem var(--sans);
+  color: var(--secondary-text-color);
 }
 
-input, select, .select, textarea {
+input, select, .select {
   position: relative;
   display: block;
   width: 100%;
   padding: 10px;
   box-sizing: border-box;
-  font-size: 0.875rem;
-  border: 1px solid #989898;
+  border: 1px solid var(--text-color);
   border-radius: 2px;
-  background-color: white;
+  color: var(--text-color);
+  background-color: var(--paper-color);
+  font-size: 0.875rem;
   transition: all 0.15s ease-in-out;
   cursor: pointer;
 }
@@ -426,14 +353,14 @@ input[type=checkbox] {
   appearance: none;
   width: 16px;
   height: 16px;
-  padding: 0;
-  border-radius: 0;
   margin: 0;
+  padding: 0;
   outline: none;
+  border-radius: 0;
 }
 
 input[type=checkbox]:checked {
-  background-color: #222;
+  background-color: var(--text-color);
   box-shadow: inset 0px 0px 0px 3px white;
 }
 
@@ -442,16 +369,16 @@ input[type=radio] {
   appearance: none;
   width: 16px;
   height: 16px;
-  border-radius: 50%;
-  border: 1px solid var(--tc, #707070);
-  padding: 0;
   margin: 0;
+  padding: 0;
   outline: none;
+  border: 1px solid var(--text-color, #707070);
+  border-radius: 50%;
 }
 
 input[type=radio]:checked {
+  box-shadow: inset 0px 0px 0px 4px var(--text-color);
   background-color: white;
-  box-shadow: inset 0px 0px 0px 4px #222;
 }
 
 input:focus, select:focus, .focus {
@@ -479,7 +406,7 @@ input:focus, select:focus, .focus {
  * Inline SVG
  */
 svg {
-  fill: var(--fc, var(--tc));
+  fill: var(--fill-color, var(--link-color));
 }
 
 /** 
@@ -488,20 +415,21 @@ svg {
 figure {
   position: relative;
   display: grid;
-  gap: 10px;
-  margin: 0;
   flex: none;
+  gap: var(--space-sm);
+  margin: 0;
 }
 
 figure img {
   display: block;
   width: 100%;
   height: auto;
+  background-color: var(--media-background-color);
 }
 
 figcaption, .caption {
   font: 400 0.875rem/1.4em var(--sans);
-  color: var(--tc, var(--gray));
+  color: var(--caption-color, var(--secondary-text-color));
 }
 
 /**
@@ -509,98 +437,41 @@ figcaption, .caption {
  */
 .paper {
   position: relative;
-  background-color: var(--paper-color, white);
   box-shadow: var(--paper-shadow);
-  color: var(--tc);
+  background-color: var(--paper-color);
+  color: var(--text-color);
 }
 
-.paper * {
+.paper *,
+.card *,
+.digest * {
   --paper-shadow: none;
 }
 
-/**
- * Vertical and horizontal stacks
+/*
+ * MMN disclaimer for header and footer
  */
-.stack,
-.package,
-.card {
-  display: flex;
-  flex-direction: column;
-  align-items: start;
-  gap: var(--spread);
-  --display: flex;
-}
-
-.stack > *,
-.package > *,
-.card > * {
+.mmn-company {
   margin: 0;
+  padding: 1em 0;
+  font: bold 10px var(--sans);
+  text-align: center;
+  color: var(--text-color);
 }
 
-.row {
-  display: flex;
-  align-items: var(--row-align, center);
-  gap: var(--spread);
-  --display: flex;
-}
-
-.package {
-  padding: calc(var(--gap) / 2);
-  color: var(--tc);
-  flex: 1;
-  --ht: none;
-  --hw: normal;
-  --hf: var(--serif);
-  --ld: none;
-  --lhd: underline;
-  --lc: var(--lc, inherit);
-  --lhc: var(--lc, inherit);
-}
-
-.package.no-img {
-  --hs: x-large;
-}
-
-.package img {
-  max-width: 100%;
-}
-
-.package > .time,
-.package > time {
-  flex: 1 1 auto;
-  display: flex;
-  align-items: end;
-}
-
-.package.thumb {
-  display: grid;
-  grid-template-columns: 1fr 90px;
-}
-
-.package.thumb > * {
-  grid-column: 1;
-}
-
-.package.thumb > [class*=img],
-.package.thumb > img {
-  grid-row: 1/span var(--thumb-span, 2);
-  grid-column: 2;
-}
-
-.package.thumb > time,
-.package.thumb > .time {
-  align-self: end;
-}
-
+/*
+ * Card is the element we'll use mostly
+ */
 .card {
   position: relative;
-  background-color: var(--paper-color, white);
-  color: var(--tc);
+  display: flex;
+  flex-direction: column;
+  align-items: var(--card-align, start);
+  gap: var(--card-gap, var(--space));
+  padding: var(--card-padding, var(--space));
+  background-color: var(--card-color, var(--paper-color));
+  color: var(--card-text-color, var(--text-color));
   box-shadow: var(--paper-shadow);
-}
-
-.card * {
-  --paper-shadow: none;
 }
 
 .card figure,
@@ -628,8 +499,91 @@ figcaption, .caption {
   }
 }
 .card.sponsored .kicker {
-  --tc: white;
-  background-color: var(--impact);
+  background-color: var(--text-color);
+  --text-color: var(--secondary-background-color);
+}
+
+.card > .package {
+  flex: 1;
+}
+
+/**
+ * Stack and row generics
+ */
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--stack-gap, var(--space-sm));
+  --display: flex;
+}
+
+.row {
+  display: flex;
+  align-items: var(--row-align, center);
+  gap: var(--row-gap, var(--space-sm));
+  --display: flex;
+}
+
+/*
+ * Packages are stacks, but introduce some typography rules
+ */
+.package {
+  display: flex;
+  flex-direction: column;
+  gap: var(--package-gap, var(--space-sm));
+  align-items: var(--package-align, start);
+  padding: var(--package-padding, 0);
+  --header-family: var(--serif);
+  --header-weight: normal;
+  --header-transform: none;
+  --link-color: var(--text-color);
+  --link-decoration: none;
+  --link-hover-decoration: underline;
+}
+
+.package.no-img {
+  --h3: x-large;
+}
+
+.package img {
+  max-width: 100%;
+}
+
+.package > .time,
+.package > time {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: end;
+}
+
+.package.thumb {
+  display: grid;
+  grid-template-columns: 1fr 90px;
+}
+
+.package.thumb > * {
+  grid-column: 1;
+}
+
+.package.thumb > [class*=img],
+.package.thumb > img {
+  grid-row: 1/span var(--thumb-span, 2);
+  grid-column: 2;
+}
+
+.package.thumb > time,
+.package.thumb > .time {
+  align-self: end;
+}
+
+/*
+ * Children for all concepts
+ */
+.stack > *,
+.row > *,
+.package > *,
+.card > * {
+  margin: 0;
 }
 
 /**
@@ -637,10 +591,10 @@ figcaption, .caption {
  */
 .slider {
   text-align: center;
-  overflow-x: scroll;
   white-space: nowrap;
+  overflow-x: scroll;
   scrollbar-width: thin;
-  scrollbar-color: var(--scrollbar-foreground, #0007) var(--scrollbar-background, transparent);
+  scrollbar-color: var(--scrollbar-foreground, var(--black)) var(--scrollbar-background, transparent);
 }
 
 .slider .row {
@@ -666,21 +620,21 @@ section, .section {
   display: block;
   position: relative;
   max-width: var(--section-width);
-  margin: var(--gap) auto;
+  margin: var(--space) auto;
 }
 
 #main-content,
 .videoIngest #vueContainer {
   display: block;
+  max-width: unset;
   margin: 0;
   padding: 0;
-  max-width: unset;
 }
 
 .section-label {
-  margin: 0;
-  font-weight: bold;
+  margin: 0 0 10px 0;
   padding: 0 var(--page-padding);
+  font-weight: bold;
 }
 
 .section-title h5 {
@@ -700,20 +654,20 @@ section, .section {
  * Expander 
  */
 .expander {
-  cursor: pointer;
   display: flex;
   align-items: center;
   outline: none;
+  cursor: pointer;
 }
 
 .expander:after {
   content: "";
   display: inline-block;
   clip-path: polygon(0% 0%, 50% 80%, 100% 0%, 100% 20%, 50% 100%, 0% 20%, 0% 0%);
-  width: 0.8em;
-  height: 0.48em;
   max-width: 15px;
+  width: 0.8em;
   max-height: 9px;
+  height: 0.48em;
   margin-left: 5px;
   transition: transform 0.5s ease;
   transform-origin: 50%;
@@ -736,22 +690,55 @@ section, .section {
  * Social media 
  */
 .social-media {
-  display: flex;
   place-content: center;
-  gap: 15px;
+  display: flex;
+  gap: var(--social-media-gap, var(--space-sm));
 }
 
 .social-media svg {
-  height: 20px;
+  display: block;
   width: 20px;
+  height: 20px;
+}
+
+/*
+ * Partner labels
+ */
+.partner-label {
+  position: relative;
+  grid-column: 1/-1;
+  font: 700 1.8rem var(--serif);
+  color: var(--header-color);
+}
+
+@media (max-width: 600px) {
+  .partner-label {
+    margin: var(--page-padding);
+  }
+}
+.partner-label::before {
+  content: "";
+  position: absolute;
+  display: block;
+  top: 50%;
+  width: 100%;
+  height: 4px;
+  background-color: #ddd;
+}
+
+.partner-label span {
+  position: relative;
+  padding-right: 15px;
+  background-color: var(--background-color);
 }
 
 /**
  * Flag styles
  */
 .masthead {
-  --paper-color: transparent;
+  --paper-color: var(--background-color);
   --paper-shadow: none;
+  --link-color: black;
   z-index: 2;
 }
 
@@ -761,10 +748,11 @@ body.wirestory .masthead {
 }
 
 html.msb .masthead {
-  --paper-color: var(--premium-bc);
-  --tc: var(--premium-tc);
-  --lc: var(--premium-tc);
-  --border-color: var(--premium-tc);
+  --paper-color: var(--sub-blue);
+  --text-color: var(--sub-text-color);
+  --link-color: var(--sub-text-color);
+  --border-color: var(--sub-text-color);
+  --fill-color: var(--sub-text-color);
 }
 
 .sds-flag {
@@ -776,16 +764,15 @@ html.msb .masthead {
   padding: var(--page-padding);
   padding-bottom: 0;
   font: bold 13px/1em var(--sans);
-  color: var(--tc);
+  color: var(--text-color);
   /* Custom properties for kids */
-  --spread: 15px;
-  --ld: none;
-  --tc: var(--black);
+  --link-decoration: none;
+  --text-color: var(--black);
 }
 
 .msb .sds-flag {
   grid-template-areas: "menu . account" "edition edition edition" "logo logo logo" "nav nav nav";
-  --tc: var(--premium-tc);
+  --text-color: var(--sub-text-color);
 }
 
 @media (min-width: 768px) {
@@ -819,7 +806,7 @@ html.msb .masthead {
 
 .flag-menu {
   grid-area: menu;
-  --spread: 15px;
+  --row-gap: 15px;
 }
 
 .flag-menu button,
@@ -829,49 +816,44 @@ html.msb .masthead {
 }
 
 .sds-flag .search {
-  --spread: 10px;
+  --row-gap: 10px;
 }
 
 .sds-flag .search input {
+  position: relative;
+  bottom: 5px;
   margin-top: 0;
-  background-color: transparent;
   border: none;
   border-bottom: 1px solid transparent;
   padding: 5px 0px;
-  color: var(--tc);
-  position: relative;
-  bottom: 5px;
+  background-color: transparent;
+  color: var(--text-color);
 }
 
 .sds-flag .search input:focus,
 .sds-flag .search input:not(:placeholder-shown) {
   box-shadow: none;
   outline: none;
-  border-color: var(--tc);
+  border-color: var(--text-color);
 }
 
 .flag-account {
   grid-area: account;
   place-self: end;
   min-height: 30px;
-  --bc: var(--premium-tc);
-  --bbc: var(--premium-bc);
-  --lhd: underline;
 }
 
 .flag-account .button {
   font-size: 1em;
-}
-
-.flag-account .button:hover {
-  --bc: var(--premium-impact);
+  --button-color: var(--white);
+  --button-hover-color: var(--sub-secondary-text-color);
 }
 
 .flag-left {
   grid-area: left;
   font-size: 14px;
-  --spread: 7px;
-  --lhd: underline;
+  --statck-gap: 7px;
+  --link-hover-decoration: underline;
 }
 
 .flag-right {
@@ -879,8 +861,8 @@ html.msb .masthead {
   justify-self: end;
   align-items: end;
   font-size: 14px;
-  --spread: 7px;
-  --lhd: underline;
+  --stack-gap: 7px;
+  --link-hover-decoration: underline;
 }
 
 .flag-edition {
@@ -894,11 +876,11 @@ html.msb .masthead {
   content: "";
   width: 30px;
   height: 1px;
-  background-color: var(--premium-impact);
+  background-color: var(--sub-secondary-text-color);
 }
 
 .msb .flag-edition {
-  color: var(--premium-impact);
+  color: var(--sub-secondary-text-color);
 }
 
 .flag-logo {
@@ -907,8 +889,8 @@ html.msb .masthead {
 
 .logo {
   width: 100%;
-  height: auto;
   max-height: 75px;
+  height: auto;
 }
 
 .flag-nav {
@@ -917,14 +899,15 @@ html.msb .masthead {
   border-bottom: 1px solid var(--border-color, var(--black));
   font-size: 16px;
   padding: 17px 0 15px;
-  --lhd: underline;
+  --link-hover-color: var(--text-color);
+  --link-hover-decoration: underline;
   /* Hides the bottom border for decks without the premium topper */
   position: relative;
   top: 1px;
 }
 
 .msb .flag-nav {
-  --scrollbar-foreground: var(--premium-impact);
+  --scrollbar-foreground: var(--sub-secondary-text-color);
 }
 
 .flag-nav .separator ~ * {
@@ -940,27 +923,27 @@ html.msb .masthead {
 
 .sds-flag .popout {
   position: absolute;
+  z-index: 99;
   top: 100%;
   right: 0px;
   min-width: 210px;
-  font-size: 0.875rem;
-  background-color: white;
-  z-index: 99;
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
-  --tc: var(--black);
-  --lc: var(--black);
-  --lhc: var(--black);
-  --lhd: none;
+  --text-color: var(--black);
+  --link-color: var(--black);
+  --link-hover-color: var(--black);
+  --link-hover-decoration: none;
+  background-color: white;
+  font-size: 0.875rem;
 }
 
 .sds-flag .popout > * {
   display: grid;
   grid-template-columns: 20px 1fr;
   grid-gap: 30px;
-  padding: 15px;
+  align-items: center;
   box-sizing: border-box;
   min-height: 60px;
-  align-items: center;
+  padding: 15px;
 }
 
 .sds-flag .popout a:hover {
@@ -974,11 +957,11 @@ html.msb .masthead {
 
 .sds-flag .popout svg {
   width: 20px;
+  fill: inherit;
 }
 
 /**
  * Menu
- * Goes underneath the footer code in decks.css
  */
 .main-nav {
   z-index: 20;
@@ -988,10 +971,15 @@ html.msb .masthead {
   bottom: 0;
   width: 260px;
   padding-bottom: 30px;
+  background-color: var(--nav-color, var(--black));
   overflow: scroll;
   -webkit-overflow-scrolling: touch;
   transform: translateX(-150%);
   transition: transform 0.4s ease;
+}
+
+.main-nav:hover :focus {
+  outline: none;
 }
 
 .main-nav.open {
@@ -1012,27 +1000,23 @@ html.msb .masthead {
   border: none;
   border-left: 5px solid transparent;
   border-radius: 0;
-  cursor: pointer;
   background-color: transparent;
-  color: white;
+  cursor: pointer;
+  color: var(--nav-text-color, var(--white));
 }
 
 .main-nav button {
   font-weight: bold;
 }
 
-.main-nav:hover :focus {
-  outline: none;
-}
-
-.main-nav button:hover,
-.main-nav a:hover {
-  background-color: #222;
-}
-
 .main-nav a,
 .main-nav .option-label {
   display: block;
+}
+
+.main-nav hr {
+  border: 0.5px solid var(--nav-text-color, var(--white));
+  margin: 30px 0;
 }
 
 .main-nav .expander {
@@ -1043,38 +1027,26 @@ html.msb .masthead {
 
 .main-nav .subsection a {
   padding: 10px 30px 10px 45px;
-  color: #989898;
+  color: var(--nav-section-text-color, var(--gray));
 }
 
 .main-nav .subsection a:hover {
-  color: white;
+  color: var(--nav-text-color, var(--white));
 }
 
 .main-nav .expander.open,
 .main-nav .expander.open + div a,
 .main-nav .option-label {
-  background-color: #222;
-  border-color: #fff;
-}
-
-.main-nav hr {
-  border: 0.5px solid white;
-  margin: 30px 0;
-}
-
-.main-nav .flex {
-  display: flex;
-  align-items: center;
-  gap: 10px;
+  background-color: black;
+  border-color: var(--nav-text-color, var(--white));
 }
 
 .main-nav .search {
-  background-color: #5f5f5f;
   height: 58px;
 }
 
 .main-nav .search form {
-  border-bottom: 1px solid white;
+  border-bottom: 1px solid var(--nav-text-color, var(--white));
   width: 100%;
   display: none;
 }
@@ -1087,26 +1059,26 @@ html.msb .masthead {
   display: none;
 }
 
+.main-nav .search form svg {
+  height: 12px;
+}
+
 .main-nav .search input {
   background-color: transparent;
   border: none;
-  color: white;
+  color: var(--nav-text-color, var(--white));
   padding-left: 0px;
   margin: 0;
   flex: 1;
 }
 
 .main-nav .search ::placeholder {
-  color: white;
+  color: var(--nav-section-text-color, var(--gray));
 }
 
 .main-nav .search button {
   padding: 0;
   width: auto;
-}
-
-.main-nav .search form svg {
-  height: 12px;
 }
 
 .main-nav .search button:hover {
@@ -1116,13 +1088,19 @@ html.msb .masthead {
 /**
  * Footer
  *
- * Note: this card could use a DOM refresher
+ * This card is essentially frozen, and I've hard-coded several
+ * of the spacing properties to ensure theming doesn't affect them.
  */
+footer {
+  background-color: var(--footer-color, var(--paper-color));
+  color: var(--footer-text-color, var(--text-color));
+}
+
 .footer {
   margin: 0 auto;
   padding: var(--page-padding);
   display: grid;
-  gap: var(--gap);
+  gap: 30px;
   font: 16px var(--sans);
 }
 
@@ -1132,33 +1110,29 @@ html.msb .masthead {
   padding: 0;
   max-width: 340px;
   align-self: start;
-  --hf: var(--sans);
-  --hw: bold;
+  --header-family: var(--sans);
+  --header-weight: bold;
 }
 
-.footer-connect .flex {
+.footer .flex {
   display: flex;
-  gap: 10px;
   align-items: center;
+  gap: 10px;
 }
 
 .footer svg,
 .footer .icon {
   height: 30px;
   width: 30px;
-}
-
-.footer .icon {
-  background-color: white;
-  border-radius: 20%;
+  --fill-color: var(--text-color);
 }
 
 .footer .icon img {
   display: block;
+  margin: 1px 0 0 1px;
   border-radius: 20%;
   width: 28px;
   height: 28px;
-  margin: 1px 0 0 1px;
 }
 
 .footer .social {
@@ -1168,18 +1142,19 @@ html.msb .masthead {
 }
 
 .footer .social svg {
-  height: 35px;
   width: 35px;
+  height: 35px;
 }
 
 .footer-links {
   display: flex;
   flex-direction: column;
-  gap: 30px;
   justify-content: space-between;
+  gap: 30px;
 }
 
 .footer-links .package {
+  --link-color: var(--header-color);
   padding: 0;
 }
 
@@ -1190,6 +1165,7 @@ html.msb .masthead {
 .bottom-nav a {
   display: block;
   padding: 15px;
+  --link-color: var(--text-color);
 }
 
 @media (min-width: 600px) {
@@ -1213,20 +1189,25 @@ html.msb .masthead {
     justify-content: end;
   }
 }
-/**
+/*
  * Section grid
  */
 .grid {
   display: grid;
   grid-template-columns: var(--columns);
-  gap: var(--gap);
-  grid-auto-flow: dense;
+  gap: var(--grid-row-gap) var(--grid-column-gap);
+  grid-auto-flow: var(--grid-flow, dense);
 }
 
 .grid > .package:not(.no-img) {
-  --gap: 0px;
+  --package-padding: 0px;
 }
 
+@media (max-width: 600px) {
+  .grid {
+    --grid-row-gap: 2px;
+  }
+}
 /*
  * Utilities 
  */
@@ -1272,7 +1253,7 @@ html.msb .masthead {
     grid-row-start: 6;
   }
 }
-/**
+/*
  * Load more button
  */
 .load-more {
@@ -1281,18 +1262,35 @@ html.msb .masthead {
   justify-content: center;
 }
 
-/**
+/*
  * Custom grid arrangements
  */
-.partner-digest-group .digest {
+[class*=digest-group] {
+  display: grid;
+  grid-column: 1/-1;
+  grid-template-columns: var(--columns);
+  grid-gap: var(--grid-row-gap) var(--grid-column-gap);
+  margin: 0;
+  padding: 0;
+}
+
+[class*=digest-group] .digest {
   grid-column: auto;
 }
 
-/**
- * Custom cards injectable element
+/*
+ * Regions are invisible wrappers for Taboola 
+ * dynamic injection, same as custom-cards
  */
-custom-card {
+.region, custom-card {
   display: contents;
+}
+
+/*
+ * Options banner is at the top of all grids
+ */
+.option-banners {
+  grid-column: 1/-1;
 }
 
 /**
@@ -1300,19 +1298,18 @@ custom-card {
  */
 .story-body {
   display: flow-root;
-  color: var(--tc);
-  font: 18px/1.5em var(--serif);
-  --hf: var(--sans);
-  --ht: uppercase;
-  --lc: #5169B8;
-  --lhc: #31409F;
-  --ld: underline;
+  font: var(--story-font, 18px/2em var(--serif));
+  line-height: 1.6em;
+  color: var(--story-text-color, var(--text-color));
+  background-color: var(--story-background-color, var(--paper-color));
+  --header-family: var(--story-subhead-family, var(--sans));
+  --header-transform: var(--story-subhead-transform, uppercase);
 }
 
 .story-body > * {
   max-width: var(--story-width);
+  margin: var(--space) auto;
   padding: 0 var(--page-padding);
-  margin: 20px auto;
 }
 
 .story-body > .header {
@@ -1323,16 +1320,11 @@ custom-card {
  * Embeds
  */
 .story-body .embed-infographic {
-  margin: 30px auto;
-  clear: both;
+  max-width: var(--story-embed-width);
 }
 
 .embed-infographic > * {
   max-width: 100%;
-}
-
-.story-body > .story-module {
-  margin: 30px auto;
 }
 
 /**
@@ -1341,12 +1333,12 @@ custom-card {
 .story-body > figure,
 .story-body > .figure,
 .story-body > .inline-video {
+  max-width: var(--story-media-width);
   margin: 30px auto;
-  padding: 0;
 }
 
 .story-body .wide {
-  max-width: 970px;
+  max-width: max(970px, var(--story-media-width));
 }
 
 .story-body .full-bleed {
@@ -1356,72 +1348,20 @@ custom-card {
 
 .story-body > .full-bleed:first-child {
   margin-top: 0;
+  background-color: var(--paper-color);
 }
 
-.story-body figure,
-.story-body .figure {
-  --spread: 10px;
-}
-
-.story-body figure .package,
-.story-body .figure .package {
-  padding: 0px;
-}
-
-@media (max-width: 768px) {
-  .story-body > figure,
-.story-body > .figure {
-    max-width: 100%;
-  }
-
-  .story-body figcaption,
-.story-body figure .package,
-.story-body .figure .package {
-    padding: 0px 15px;
-  }
-}
-@media (max-width: 990px) {
-  .story-body .wide figcaption,
-.story-body figure.wide .package,
-.story-body .figure.wide .package {
-    padding: 0px 15px;
-  }
-}
-.story-body .full-bleed figcaption,
-.story-body figure.full-bleed .package,
-.story-body .figure.full-bleed .package {
-  padding: 0px 15px;
-}
-
-/**
- * Asides
- */
-.story-body aside > * {
-  margin: 30px auto;
-}
-
-@media (min-width: 930px) {
-  .story-body aside > * {
-    float: right;
-    margin: 0 -150px 30px 30px;
-  }
-
-  .story-body aside.left > * {
-    float: left;
-    margin: 0 30px 30px -150px;
-  }
-}
 /**
  * Mugshots
  */
 .story-body .mugshot {
-  padding: 0 15px;
+  padding: 0 var(--space-sm);
 }
 
 .story-body .mugshot .img-container {
   display: grid;
   grid-template-columns: 125px 1fr;
-  grid-gap: 15px;
+  grid-gap: var(--space-sm);
 }
 
 .story-body .mugshot figcaption {
@@ -1430,19 +1370,10 @@ custom-card {
 }
 
 /**
- * Immersive card 
- */
-.story-body > .immersive {
-  max-width: 100%;
-  padding-top: 0;
-  margin-top: 0;
-}
-
-/**
  * Panel settings for story bodies
  */
 .story-body .panel {
-  --paper-color: var(--body-background);
+  background-color: var(--background-color);
 }
 
 /*
@@ -1450,12 +1381,12 @@ custom-card {
  */
 .amp-rm-wrapper {
   position: relative;
+  z-index: 99;
   display: grid;
   place-items: center;
   margin: -100px auto 0;
   padding: 100px 30px 30px;
   background: linear-gradient(transparent, rgba(255, 255, 255, 0.7) 20%, white 45%);
-  z-index: 99;
 }
 
 /**
@@ -1484,14 +1415,14 @@ custom-card {
 .topper {
   display: none;
   position: relative;
-  background-color: var(--premium-bc);
-  color: var(--premium-tc);
-  padding: var(--gap) var(--page-padding);
+  padding: var(--space) var(--page-padding);
+  background-color: var(--sub-blue);
+  color: var(--sub-text-color);
   font: 1rem/1.5em var(--sans);
-  --tc: white;
-  --lc: white;
-  --ld: underline;
-  --lhc: var(--premium-impact);
+  --text-color: white;
+  --link-color: white;
+  --link-decoration: underline;
+  --link-hover-color: var(--sub-secondary-text-color);
 }
 
 .msb .topper:not(.loaded) {
@@ -1512,32 +1443,32 @@ custom-card {
   left: 0;
   width: 100%;
   height: calc(50px + 8vw);
-  background-color: var(--premium-bc);
+  background-color: var(--sub-blue);
 }
 
 /**
  * Light DOM styles for the portal
  */
 .msb .topper h3 {
-  --hs: 13px;
-  --hf: var(--sans);
-  --hc: var(--premium-impact);
-  --ht: uppercase;
+  --h3: 13px;
+  --header-family: var(--sans);
+  --header-color: var(--sub-secondary-text-color);
+  --header-transform: uppercase;
 }
 
 .msb .topper [slot=headline] {
-  --hs: 8vw;
-  --hw: normal;
-  --hl: 1.1em;
-  --hf: var(--premium-serif);
-  --hc: var(--premium-tc);
-  --ht: none;
+  --h1: 8vw;
+  --header-weight: normal;
+  --header-leading-size: 1.1em;
+  --header-family: var(--premium-serif);
+  --header-color: var(--sub-text-color);
+  --header-transform: none;
   margin: 0;
 }
 
 @media (min-width: 768px) {
   .msb .topper [slot=headline] {
-    --hs: 54px;
+    --h1: 54px;
   }
 }
 .msb .topper li {
@@ -1546,11 +1477,11 @@ custom-card {
 
 .msb .topper ul li::marker {
   content: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSIxMiI+CiAgPGNpcmNsZSBjeD0iNiIgY3k9IjYiIHI9IjYiIGZpbGw9IndoaXRlIi8+CiAgPGNpcmNsZSBjeD0iNiIgY3k9IjYiIHI9IjQiIGZpbGw9IiNlMjQ4NDgiLz4KPC9zdmc+Cg==");
-  border: 2px solid var(--premium-tc);
+  border: 2px solid var(--sub-text-color);
 }
 
 .msb .topper ol li::marker {
-  color: var(--premium-impact);
+  color: var(--sub-secondary-text-color);
   font-size: 0.85em;
   font-weight: bold;
 }
@@ -1562,7 +1493,7 @@ custom-card {
   position: relative;
   width: 100%;
   padding-top: 56.25%;
-  background-color: #222;
+  background-color: var(--text-color);
 }
 
 .embed-video-wrapper iframe {
@@ -1576,7 +1507,15 @@ custom-card {
 
 /**
  * Flexbox grid
+ *
+ * Deprecated. Should be removed once no longer used.
  */
+.flex {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
 .flex-columns > * {
   margin: 30px 0;
 }
@@ -1586,7 +1525,7 @@ custom-card {
 }
 
 .flex-columns .lead-item .package {
-  --hw: bold;
+  --header-weight: bold;
 }
 
 @media (min-width: 690px) {
@@ -1633,32 +1572,38 @@ custom-card {
     padding-top: 15px;
   }
 }
-/**
+/*
  * Zones
+ * 
+ * Deprecated the `.zone` class due to ad-blockers.
  */
-.zone {
-  display: grid;
-  clear: both;
+[data-type=ad] {
+  padding: var(--space) 0;
+  background-color: var(--zone-background-color, var(--media-background-color));
 }
 
-.zone:empty {
-  display: none;
+@media (max-width: 600px) {
+  [data-type=ad] {
+    background-color: var(--zone-background-color, var(--background-color));
+  }
 }
-
-/**
+/*
  * Zone treatment inside grids
  */
-.grid .zone {
+/* .grid .zone { */
+.grid [data-type=ad] {
   grid-column-end: -1;
-  background-color: var(--ad-background);
 }
 
 /*
  * Zones inside story bodies
  */
-.story-body > .zone {
-  padding: 0;
+.story-body [data-type=ad] {
   box-sizing: border-box;
+  margin: var(--space-lg) 0;
+  padding: 0;
+  max-width: unset;
+  --zone-background-color: transparent;
 }
 
 .zone.combo {
@@ -1666,17 +1611,17 @@ custom-card {
   justify-items: center;
 }
 
-/**
+/*
  * Custom changes
  */
-#zone-el-2 {
-  position: relative;
-  background-color: var(--black);
+#zeus_top-banner {
   padding: 15px 0;
 }
 
-#zeus_top-banner {
-  padding: 15px 0;
+.story-body > .stn-player {
+  max-width: var(--story-width);
+  margin: 40px auto;
+  padding: 0;
 }
 
 /**
@@ -1685,24 +1630,33 @@ custom-card {
 .digest {
   display: grid;
   grid-template-rows: 1fr auto;
-  background-color: var(--paper-color, white);
+  grid-gap: var(--space);
+  background-color: var(--card-color, var(--paper-color));
   box-shadow: var(--paper-shadow);
-  color: var(--tc);
+  padding: var(--digest-padding, var(--space));
+  --card-padding: 0;
+  --card-gap: var(--space-sm);
+  --package-padding: 0;
 }
 
-.digest .paper {
-  --paper-shadow: none;
+.digest > .paper {
+  display: grid;
+  grid-gap: var(--space);
+  align-content: start;
+  background-color: var(--card-color, var(--paper-color));
 }
 
 .digest .more-link {
   align-self: end;
-  padding: 15px 15px 10px;
-  --tc: var(--black);
+}
+
+.digest .label {
+  display: block;
 }
 
 /**
  * Immersive media card
- * Note: this could be made smaller with custom properties later
+ * Note: This needs to be removed from the system
  */
 .immersive {
   margin-top: 0;
@@ -1723,7 +1677,7 @@ custom-card {
   justify-content: flex-end;
   text-align: center;
   padding-bottom: 30px;
-  --bbc: transparent;
+  --button-background-color: transparent;
 }
 
 .immersive .content > * {
@@ -1743,12 +1697,23 @@ custom-card {
 .immersive .title {
   font: 700 2.5em/1.1em var(--serif);
   text-transform: none;
-  --lc: white;
-  --lhc: white;
-  --ld: none;
-  --lhd: underline;
+  --link-color: white;
+  --link-hover-color: white;
+  --link-decoration: none;
+  --link-hover-decoration: underline;
 }
 
+.immersive .kicker {
+  --link-color: white;
+  --link-hover-color: white;
+  --link-decoration: none;
+}
+
+@media (min-width: 760px) {
+  .immersive .title {
+    font-size: 64px;
+  }
+}
 .immersive-summary {
   font-size: larger;
 }
@@ -1757,11 +1722,12 @@ custom-card {
   padding: 10px 15px 0;
 }
 
-@media (min-width: 760px) {
-  .immersive .title {
-    font-size: 64px;
-  }
+.story-body > .immersive {
+  max-width: 100%;
+  margin-top: 0;
+  padding: 0;
 }
+
 .search-form {
   margin: 50px 0;
   display: grid;
@@ -1781,11 +1747,11 @@ custom-card {
 
 .search-form .select .button {
   justify-content: space-between;
+  padding: 0;
   font-weight: normal;
   text-transform: none;
-  padding: 0;
-  --bc: var(--black);
-  --bbc: transparent;
+  --button-color: var(--black);
+  --button-background-color: transparent;
 }
 
 .search-form .select .options a {
@@ -1808,12 +1774,12 @@ custom-card {
  */
 .header {
   display: grid;
-  gap: 15px;
+  gap: var(--space-sm);
   justify-items: center;
   text-align: center;
-  --hf: var(--serif);
-  --hw: bold;
-  --ht: none;
+  --header-family: var(--serif);
+  --header-weight: bold;
+  --header-transform: none;
 }
 
 .header > * {
@@ -1822,22 +1788,16 @@ custom-card {
 
 .bio {
   display: grid;
-  gap: 15px;
+  gap: var(--space-sm);
+  justify-items: center;
+  text-align: center;
+  line-height: 1.2em;
 }
 
 .bio .byline {
   margin: 0;
 }
 
-@media (min-width: 600px) {
-  .header .bio {
-    display: flex;
-    justify-self: stretch;
-    align-items: center;
-    justify-content: space-between;
-    text-align: left;
-  }
-}
 /**
  * Opinion changes
  */
@@ -1847,7 +1807,7 @@ custom-card {
 
 .header.opinion .bio {
   display: grid;
-  gap: var(--spread);
+  gap: var(--space-sm);
   justify-items: center;
   justify-content: center;
   text-align: center;
@@ -1875,12 +1835,18 @@ custom-card {
 .opinion-banner {
   display: grid;
   grid-template-columns: 35px min-content 1fr;
-  grid-column-gap: 15px;
+  grid-column-gap: var(--space-sm);
   grid-row-gap: 5px;
+  align-items: center;
   max-width: var(--story-width);
   margin: 0 auto;
   padding: 15px;
-  color: white;
+  background-color: var(--paper-color);
+  color: var(--text-color);
+}
+
+.opinion-banner * {
+  margin: 0;
 }
 
 .opinion-banner svg {
@@ -1889,13 +1855,10 @@ custom-card {
   width: 100%;
 }
 
-.opinion-banner * {
-  margin: 0;
-}
-
 @media (max-width: 700px) {
   .opinion-banner {
     grid-template-columns: 35px 1fr;
+    align-items: start;
   }
 
   .opinion-banner svg {
@@ -1905,20 +1868,17 @@ custom-card {
 /**
  * Series nav
  */
-.series-nav {
-  padding: 0;
-}
-
+.series-nav,
 .series-nav .package {
   padding: 0;
 }
 
 .series-nav hr {
-  border-color: var(--tc, #dfdfdf);
+  border-color: var(--series-nav-color, var(--secondary-text-color));
 }
 
 .series-nav .summary {
-  color: var(--tc, #707070);
+  color: var(--secondary-text-color);
 }
 
 .series-nav .article {
@@ -1929,16 +1889,11 @@ custom-card {
   width: 80px;
 }
 
-/** Unnecessary in 1.12 */
-.series-nav .article img {
-  padding: 0;
-}
-
 .series-nav .article h4 {
   flex: 1;
-  padding: 0 15px;
-  margin: 0;
   max-width: 375px;
+  margin: 0;
+  padding: 0 15px;
 }
 
 .correction {
@@ -1952,11 +1907,6 @@ custom-card {
 /**
  * Related stories
  */
-.related-stories {
-  --lc: #222;
-  --lhc: #222;
-}
-
 .related-stories h5 {
   margin-top: 0;
 }
@@ -1978,9 +1928,9 @@ custom-card {
   font-family: var(--sans);
   font-size: 0.875rem;
   align-items: center;
-  --lc: var(--gray);
-  --ld: none;
-  --ht: none;
+  --package-padding: var(--space-sm) 0;
+  --link-decoration: none;
+  --header-transform: none;
   --gap: 0;
 }
 
@@ -2003,7 +1953,6 @@ custom-card {
 
 .author-card > .flex {
   display: grid;
-  gap: var(--spread);
   grid-area: info;
   justify-items: start;
 }
@@ -2022,9 +1971,9 @@ custom-card {
 .author-bio {
   padding: 0 var(--page-padding);
   grid-template-columns: auto 1fr;
-  grid-row-gap: var(--spread);
+  grid-row-gap: var(--space-sm);
   grid-template-areas: "thumb info" "bio bio" "contact contact";
-  --hw: 400;
+  --header-weight: 400;
 }
 
 .author-bio .a-details {
@@ -2041,7 +1990,7 @@ custom-card {
 }
 
 .author-bio .h6 {
-  color: var(--gray);
+  color: var(--secondary-text-color);
 }
 
 @media (min-width: 600px) {
@@ -2072,11 +2021,13 @@ custom-card {
  * Timeline
  */
 .timeline-event {
-  border-left: 1px solid var(--tc, #707070);
-  max-width: 500px;
-  --hf: var(--sans);
-  --hw: 600;
-  --ht: uppercase;
+  border-left: 1px solid var(--timeline-border-color, var(--secondary-text-color));
+  max-width: var(--timeline-max-width, 500px);
+  position: relative;
+  --header-family: var(--sans);
+  --header-weight: 600;
+  --header-transform: uppercase;
+  padding: var(--timeline-padding, calc(var(--space)*2/3) var(--space));
 }
 
 .timeline-event:before {
@@ -2084,27 +2035,23 @@ custom-card {
   position: absolute;
   top: 0;
   left: 0;
+  transform: translate(-9.5px, 12px);
   width: 18px;
   height: 18px;
   box-sizing: border-box;
-  background-color: var(--tc, #707070);
-  border: 4px solid var(--paper-color, white);
+  background-color: var(--timeline-border-color, var(--secondary-text-color));
+  border: 4px solid var(--timeline-border-color, var(--secondary-text-color));
   border-radius: 50%;
-  transform: translate(-9.5px, 12px);
 }
 
 /**
  * Transparency
  */
-.transparency {
-  max-width: 100%;
-  padding: 15px;
-  background-color: var(--paper-color, #f4f4f4);
-}
-
 .transparency > * {
-  margin: 15px auto;
+  margin: 0;
+  padding: var(--space);
   max-width: var(--story-width);
+  background-color: var(--background-color);
 }
 
 .transparency .expander {
@@ -2112,9 +2059,13 @@ custom-card {
 }
 
 .question {
-  --hf: var(--serif);
-  --hw: 400;
-  --ht: none;
+  --header-family: var(--serif);
+  --header-weight: 400;
+  --header-transform: none;
+}
+
+.question h3 {
+  margin: 0;
 }
 
 /**
@@ -2124,6 +2075,12 @@ custom-card {
  */
 section.big-news {
   padding: 0;
+}
+
+/* better handled by removing the impact class in WPS */
+.big-news .label .impact {
+  color: var(--text-color);
+  background-color: var(--paper-color);
 }
 
 .big-news .latest {
@@ -2147,25 +2104,19 @@ section.big-news {
     font-size: 3.7rem;
   }
 }
-.big-news figcaption {
-  padding: 0px 15px;
-}
-
+.big-news figcaption,
 .big-news .grid:not(.featured) {
   padding: 0 15px;
 }
 
-.big-news .grid:not(.featured) .package {
+.big-news .grid:not(.featured) .package,
+.big-news .featured .package {
   padding: 0;
 }
 
 .big-news .featured {
-  padding: 15px;
+  padding: var(--space-sm);
   --paper-shadow: none;
-}
-
-.big-news .featured .package {
-  padding: 0;
 }
 
 @media (min-width: 660px) {
@@ -2176,16 +2127,13 @@ section.big-news {
 /**
  * In Depth card
  */
-.in-depth {
-  background-color: var(--paper-color, #373737);
-}
-
 .in-depth .package {
-  --hs: 1.75rem;
-  --hw: bold;
+  --h1: 1.75rem;
+  --h3: 1.75rem;
+  --header-weight: bold;
 }
 
-.card.in-depth figure {
+.in-depth figure {
   min-height: 400px;
 }
 
@@ -2199,48 +2147,16 @@ section.big-news {
 }
 
 /**
- * SWG Promo card
- */
-.card.swg-promo .package {
-  --hw: 400;
-  --hf: var(--sans);
-}
-
-.card.swg-promo .promo {
-  background-color: var(--promo);
-  color: white;
-  justify-content: center;
-}
-
-.card.swg-promo .title {
-  --hw: bold;
-  font-size: 48px;
-}
-
-.card.swg-promo .summary {
-  font-size: medium;
-}
-
-@media (min-width: 660px) {
-  .card.swg-promo {
-    grid-template-columns: 2fr 1fr;
-  }
-
-  .card.swg-promo > :first-child {
-    min-height: 200px;
-  }
-}
-/**
  * Read Next
  */
 .read-next {
   font: medium/1.5em var(--sans);
-  --spread: 10px;
 }
 
 @media (min-width: 990px) {
   .read-next {
     grid-column: span 2;
+    grid-row: span 2;
   }
 }
 .read-next .package {
@@ -2252,8 +2168,16 @@ section.big-news {
 .read-next .header {
   align-self: stretch;
   justify-items: start;
-  text-align: left;
   padding: 0;
+  text-align: left;
+}
+
+.read-next .bio {
+  grid-template-columns: 1fr auto;
+  justify-self: stretch;
+  align-items: center;
+  justify-items: start;
+  text-align: left;
 }
 
 .read-next .social-media {
@@ -2270,14 +2194,14 @@ section.big-news {
 
 .section-nav {
   grid-column: 1/-1;
-  --lc: #707070;
-  --scrollbar-foreground: #70707040;
-  --spread: 15px;
+  --link-color: var(--secondary-text-color);
+  --scrollbar-foreground: var(--secondary-text-color);
+  --row-gap: 15px;
+  --h1: x-large;
 }
 
 .section-nav .title {
   margin: 0;
-  --hs: x-large;
 }
 
 .section-nav .slider {
@@ -2288,8 +2212,7 @@ section.big-news {
   padding-top: 10px;
   font: 12px var(--sans);
   text-transform: uppercase;
-  --lc: var(--tc, #707070);
-  --lhc: var(--tc, #222);
+  --link-hover-color: var(--text-color);
 }
 
 .section-nav .row:empty {
@@ -2302,14 +2225,16 @@ section.big-news {
   }
 }
 .inline-cta {
+  max-width: var(--story-width);
+  margin: 0 auto;
+  background-color: var(--media-background-color);
+  color: var(--text-color);
   text-align: left;
-  background-color: var(--ad-background);
-  --spread: 10px;
 }
 
 .inline-cta.package {
-  padding: 30px;
   justify-content: center;
+  padding: var(--space);
 }
 
 @media (max-width: 629px) {
@@ -2319,26 +2244,18 @@ section.big-news {
   }
 }
 .inline-cta .h1 {
-  --hf: var(--serif);
+  --header-family: var(--serif);
 }
 
 .inline-cta input {
   align-self: stretch;
 }
 
-.impact .inline-cta {
-  padding: 15px;
-  --bc: #222;
-  --bbc: white;
-  --ld: underline;
-  --lhc: #b4bbe8;
-}
-
 .upper-nav {
-  display: flex;
   position: relative;
   z-index: 11;
-  background-color: #f4f4f4;
+  display: flex;
+  background-color: var(--body-background);
 }
 
 .upper-nav .tab {
@@ -2350,13 +2267,13 @@ section.big-news {
 .upper-nav .tab img {
   display: block;
   height: 15px;
-  width: auto;
   max-width: 100%;
+  width: auto;
 }
 
 .upper-nav .tab.active {
-  background-color: white;
   border-right: 1px solid #ddd;
+  background-color: white;
 }
 
 .upper-nav .tab.active:not(:first-child) {
@@ -2368,8 +2285,8 @@ section.big-news {
  */
 .upper-nav .tab .favicon {
   max-width: unset;
-  height: 24px;
   width: 24px;
+  height: 24px;
 }
 
 .upper-nav .tab .logo {
@@ -2377,9 +2294,6 @@ section.big-news {
 }
 
 @media (min-width: 768px) {
-  /* .upper-nav .tab { */
-  /*   padding: 10px 20px; */
-  /* } */
   .upper-nav .tab .favicon {
     display: none;
   }
@@ -2392,21 +2306,21 @@ section.big-news {
  * Gallery card
  */
 .gallery {
-  font-family: var(--sans);
   align-items: unset;
-  color: var(--gray);
-  --hc: var(--black);
+  font-family: var(--sans);
+  color: var(--secondary-text-color);
+  padding: 0;
+  --header-color: var(--text-color);
 }
 
 .gallery .package {
-  --hw: 400;
-  --hf: var(--sans);
+  --header-family: var(--sans);
 }
 
 .gallery-panel {
   position: relative;
-  background-color: #ddd;
   padding-top: 56.25%;
+  background-color: #ddd;
 }
 
 .gallery-current {
@@ -2421,10 +2335,10 @@ section.big-news {
 .gallery-marker {
   display: flex;
   align-items: center;
-  color: white;
   position: absolute;
   bottom: 15px;
   left: 15px;
+  color: white;
 }
 
 .gallery-marker svg {
@@ -2434,10 +2348,10 @@ section.big-news {
 }
 
 .gallery-count {
-  color: white;
   margin-left: 10px;
   text-shadow: 1px 2px 2px rgba(0, 0, 0, 0.5);
   font-size: large;
+  color: white;
 }
 
 .gallery-button {
@@ -2450,8 +2364,8 @@ section.big-news {
   display: flex;
   align-items: center;
   outline: none;
-  cursor: pointer;
   background-color: transparent;
+  cursor: pointer;
 }
 
 .gallery-button svg {
@@ -2467,68 +2381,44 @@ section.big-news {
 }
 
 .gallery-next {
-  right: 0;
   justify-content: flex-end;
+  right: 0;
 }
 
 .gallery .package figcaption {
   padding: 0;
 }
 
-.sponsor {
-  display: grid;
-  grid-template-columns: 75px minmax(0, 1fr);
-  grid-gap: 30px;
-}
-
-.sponsor img {
-  display: block;
-  width: 100%;
-}
-
-.sponsor .package {
-  justify-content: center;
-  font: 0.875rem var(--sans);
-  --gap: 0;
-}
-
 /**
  * Panel
  */
 .panel {
-  padding: 45px var(--page-padding);
   max-width: 100%;
-  background-color: var(--paper-color);
-  color: var(--tc);
+  padding: var(--panel-padding, var(--space-lg)) var(--page-padding);
+  background-color: var(--panel-color, var(--paper-color));
   font-family: var(--sans);
-  --hf: var(--sans);
-  --hw: bold;
-  --ht: uppercase;
-  --tf: var(--sans);
-  --lc: #5169B8;
-  --lhc: #31409F;
-  --ld: underline;
+  color: var(--text-color);
+  --header-family: var(--sans);
+  --header-weight: bold;
+  --header-transform: uppercase;
+  --link-decoration: underline;
+  --grid-row-gap: var(--space-sm);
+  --grid-column-gap: var(--space-sm);
 }
 
 .panel.impact {
-  --paper-color: #373737;
-  --lc: white;
-  --ld: underline;
-  --lhc: #88B1FC;
+  --link-color: var(--text-color);
+  --link-hover-color: #88B1FC;
 }
 
 .panel > * {
   max-width: var(--story-width);
   margin: 20px auto;
-  color: var(--tc);
+  color: var(--text-color);
 }
 
 .panel > img {
   display: block;
-}
-
-.panel .grid {
-  grid-gap: 15px;
 }
 
 /**
@@ -2536,20 +2426,20 @@ section.big-news {
  */
 .tbl-feed-container {
   max-width: var(--section-width);
-  margin: 15px auto;
-  padding: 0 15px;
+  margin: var(--space-sm) auto;
+  padding: 0 var(--space-sm);
 }
 
 /**
  * Utilities
  */
 .cutout {
-  background-color: var(--bodyBackground);
+  background-color: var(--background-color);
 }
 
 .gray {
-  color: var(--tc, var(--gray));
-  --bbc: var(--tc, var(--gray));
+  color: var(--text-color, var(--gray));
+  --button-background-color: var(--text-color, var(--gray));
 }
 
 .no-caps {
@@ -2563,22 +2453,22 @@ section.big-news {
 
 .serif {
   font-family: var(--serif);
-  --hf: var(--serif);
+  --header-family: var(--serif);
 }
 
 .sans {
   font-family: var(--sans);
-  --hf: var(--sans);
+  --header-family: var(--sans);
 }
 
 .bold {
   font-weight: bold;
-  --hw: bold;
+  --header-weight: bold;
 }
 
 .soft {
   font-weight: normal;
-  --hw: normal;
+  --header-weight: normal;
 }
 
 .small {
@@ -2653,10 +2543,6 @@ section.big-news {
   --img-size: 100%;
 }
 
-.square-img {
-  /* height: min(var(--img-size, 90px), 100%); */
-}
-
 .circle-img {
   border-radius: 50%;
 }
@@ -2686,56 +2572,137 @@ section.big-news {
 
 /**
  * Purple Tuesdays
+ *
+ * Note: these things are very old and may be dead
  */
 form[id^=bx-form] {
   display: block;
 }
 
 .mi-sticky-player {
-  --ht: none;
+  --header-transform: none;
 }
 
 .mi-sticky-player figcaption {
-  font-size: 14px;
   line-height: 15px;
+  font-size: 14px;
 }
 
 .videoIngest .card.read-next {
   display: block;
 }
 
-.partner-label {
-  position: relative;
-  font: 700 1.8rem var(--serif);
-  grid-column: 1/-1;
-}
-
-.partner-label::before {
-  content: "";
-  display: block;
-  height: 4px;
-  background-color: #ddd;
-  position: absolute;
-  top: 50%;
-  width: 100%;
-}
-
-.partner-label span {
-  position: relative;
-  padding-right: 15px;
-  background-color: var(--body-background);
-}
-
 #newsletter-signUpWidget {
-  --hc: var(--black);
-  --tc: var(--black);
-  --lc: #3C4D87;
-  --lhc: #5169B8;
+  --header-color: var(--black);
+  --text-color: var(--black);
+  --link-color: #3C4D87;
+  --link-hover-color: #5169B8;
 }
 
-#newsletter-signUpWidget .button {
-  --bbc: var(--impact);
-  --bc: white;
+/*
+ * WPS breaks from recommended DOM that need fixing
+ *
+ * Other notes:
+ * + Immersive layout needs to be removed
+ * + The opinion banner needs a DOM change in WPS
+ */
+.card .card {
+  --card-padding: 0;
+}
+
+figure .img-container figcaption,
+.inline-video figcaption {
+  padding-top: 10px;
+}
+
+/* class needs removed in WPS */
+.load-more .impact {
+  color: var(--text-color);
+  background-color: var(--paper-color);
+}
+
+/* class needs removed in WPS */
+.digest .label .impact {
+  --secondary-text-color: var(--dark-gray);
+}
+
+/*
+ * Fixes related to custom cards
+ */
+custom-digest {
+  padding: var(--digest-padding, var(--space));
+  --card-padding: 0;
+  --package-padding: var(--space-sm) 0;
+}
+
+/*
+ * Digests need a cleanup in WPS
+ */
+.digest .card * {
+  order: 2;
+}
+
+.digest .card .label {
+  order: 1;
+  padding-bottom: var(--space-sm);
+}
+
+/*
+ * Nativo needs altering on their side
+ */
+.ntv-hp .ntvAdChoicesLink {
+  display: contents;
+}
+
+.ntv-hp .kicker {
+  padding: 4px 6px;
+  margin-top: -4px;
+}
+
+/*
+ * Load more buttons
+ */
+.button.big.impact.hcentered {
+  background-color: var(--impact-color, var(--black));
+  color: var(--impact-text-color, var(--white));
+}
+
+/*
+ * Search and Promo buttons
+ * impact class needs removed in WPS 
+ */
+.search-form button,
+.swg-promo button.impact {
+  --paper-color: var(--white);
+  --text-color: var(--black);
+}
+
+/*
+ * Input and submit button nested under impact
+ * impact class needs removed in WPS 
+ */
+.impact form input {
+  background-color: white;
+}
+
+.impact form .button {
+  color: white;
+}
+
+/*
+ * Breaking news banner text
+ * impact class needs removed in WPS 
+ */
+.breaking-news-organism.impact a {
+  color: inherit;
+}
+
+/*
+ * Braze notification modal
+ * to be integrated into the system
+ */
+#brzpushpermission {
+  --link-color: none;
 }
 
 .impact2020 .kicker {
@@ -2751,7 +2718,7 @@ form[id^=bx-form] {
 }
 
 .impact2020 .impact .kicker {
-  color: #222;
+  color: var(--text-color);
   background-color: white;
 }
 
@@ -2816,4 +2783,57 @@ form[id^=bx-form] {
  */
 .impact2020 .inline-immersive .title {
   font-size: 48px;
+}
+
+/*
+ * Premium theme
+ */
+[data-layout=premium] .story-body {
+  font-size: 19px;
+  font-family: "Noto Serif", serif;
+  line-height: 1.5em;
+  --story-media-width: 920px;
+  --h1: 2.4rem;
+}
+
+/*
+ * Guide theme
+ */
+[data-layout=guide] .story-body > figure,
+[data-layout=guide] .story-body > h3,
+[data-layout=guide] .story-body > h4 {
+  margin: 10px auto;
+}
+
+[data-layout=guide] .story-body > p + figure::before,
+[data-layout=guide] .story-body > p + h3::before {
+  content: "";
+  display: block;
+  height: 1px;
+  width: 100%;
+  max-width: var(--story-body);
+  margin: 60px auto;
+  background: linear-gradient(to right, transparent, #999 50%, transparent);
+}
+
+[data-layout=guide] .story-body > p + figure::before {
+  margin-top: 40px;
+}
+
+[data-layout=guide] .story-body > h3 {
+  font: 400 2rem var(--sans);
+  text-transform: none;
+}
+
+/*
+ * Dark theme
+ */
+[data-layout=dark]:root {
+  --text-color: var(--white);
+  --secondary-text-color: var(--gray);
+  --background-color: #393134;
+  --media-background-color: #393134;
+  --paper-color: var(--black);
+  --zone-background-color: #2f282b;
+  --link-color: #809fff;
 }

--- a/demo/story/index.html
+++ b/demo/story/index.html
@@ -58,21 +58,19 @@
       <div class="embed"></div>
       <p>A varus foxglove is a hair of the mind. Some posit the wavy smell to be less than childing. We can assume that any instance of a ruth can be construed as a boarish evening. However, a drill can hardly be considered a sparing brazil without also being a chick.</p>
 
-      <!-- <div class="zone grid combo"> -->
+      <div class="zone grid combo">
         <div id="zone-el-102" class="zone cap-width"></div>
         <div id="zone-el-103" class="zone cap-width"></div>
-      <!-- </div> -->
+      </div>
 
       <p>Bones are mastless crooks. This could be, or perhaps a turgent professor's drive comes with it the thought that the spousal breath is a daisy. Far from the truth, the crossbred gender reveals itself as a tailored day to those who look. The fronded parallelogram comes from an eerie throne.</p>
       <p>The fighter is a polyester. The girlish accountant comes from a petrous grease. A mandolin is the man of a kayak. The step-brother of a novel becomes a breezy linen.</p>
       <p>Before examples, quails were only daughters. Though we assume the latter, the equinoxes could be said to resemble toilful beefs. In ancient times we can assume that any instance of a clutch can be construed as a ratite centimeter. The taloned flavor comes from an oaken mexico.</p>
 
-      <!-- <div class="zone grid combo"> -->
-        <div id="zone-el-104" class="zone cap-width">
-          <p>This is a test</p>
-        </div>
+      <div class="zone grid combo">
+        <div id="zone-el-104" class="zone cap-width"></div>
         <div id="zone-el-105" class="zone cap-width"></div>
-      <!-- </div> -->
+      </div>
 
       <p>The destined employer comes from an elfish headline. Some assert that some modish bakers are thought of simply as prices. In modern times the amusement is an ounce. They were lost without the tenor phone that composed their james.</p>
       <div class="embed"></div>
@@ -114,13 +112,13 @@
       <p>The single is a psychiatrist. One cannot separate hardboards from cisted partridges. We know that a product is the hallway of a crab. A company is an instrument's spear.</p>
       <h3>Subhead</h3>
 
-      <!-- <div id="zone-el-112" class="zone"></div> -->
+      <div id="zone-el-112" class="zone"></div>
 
       <div class="embed"></div>
       <p>It's an undeniable fact, really; few can name a swainish ounce that isn't a freeing crook. The flexile rhinoceros comes from a canine pamphlet. A ball is a cabinet from the right perspective. In recent years, a character is the triangle of a punishment.</p>
       <p>Unfortunately, that is wrong; on the contrary, tsunamis are barebacked rains. Extending this logic, those archeologies are nothing more than dreams. Before margarets, bestsellers were only routers. A curbless help without men is truly a detective of wheyey drinks.</p>
 
-      <!-- <div id="zone-el-113" class="zone"></div> -->
+      <div id="zone-el-113" class="zone"></div>
 
       <p>The parrot is a fat. To be more specific, they were lost without the jumpy amusement that composed their camp. It's an undeniable fact, really; before ophthalmologists, waterfalls were only interactives. To be more specific, authors often misinterpret the fedelini as a witless titanium, when in actuality it feels more like a stinko frame.</p>
       <p>This is not to discredit the idea that a cocoa is the pisces of an actress. Their kenneth was, in this moment, a menseful harbor. The chill of a hydrant becomes a dressy cloud. This is not to discredit the idea that the first turdine tank is, in its own way, an advertisement.</p>

--- a/demo/story/index.html
+++ b/demo/story/index.html
@@ -39,7 +39,7 @@
   </head>
 
   <body>
-    <!-- <div id="zone-el-1"></div> -->
+    <div id="zone-el-1"></div>
 
     <div class="card flag"></div>
 
@@ -53,63 +53,73 @@
       <p>The zeitgeist contends that a mile sees a hall as a tripping plasterboard. Framed in a different way, a noiseless note is a boundary of the mind. A mussy credit without flames is truly a alloy of android perfumes. It's an undeniable fact, really; before smashes, soldiers were only fragrances.</p>
       <p>Recent controversy aside, the spinach of a certification becomes an impure relation. Some unfought losses are thought of simply as emeries. To be more specific, a sugared day without lotions is truly a hardboard of gyral flags. A booted intestine without earths is truly a lentil of deposed pancreases.</p>
 
-      <div id="zone-el-101" class="zone" stnplayerkill="false" allowstnplayer="true"></div>
+      <!-- <div id="zone-el-101" class="zone" stnplayerkill="false" allowstnplayer="true"></div> -->
 
       <div class="embed"></div>
       <p>A varus foxglove is a hair of the mind. Some posit the wavy smell to be less than childing. We can assume that any instance of a ruth can be construed as a boarish evening. However, a drill can hardly be considered a sparing brazil without also being a chick.</p>
 
-      <div class="zone grid combo">
-        <div id="zone-el-102" class="zone cap-width"></div>
-        <div id="zone-el-103" class="zone cap-width"></div>
-      </div>
+      <!-- <div class="zone grid combo"> -->
+      <!--   <div id="zone-el-102" class="zone cap-width"></div> -->
+      <!--   <div id="zone-el-103" class="zone cap-width"></div> -->
+      <!-- </div> -->
 
       <p>Bones are mastless crooks. This could be, or perhaps a turgent professor's drive comes with it the thought that the spousal breath is a daisy. Far from the truth, the crossbred gender reveals itself as a tailored day to those who look. The fronded parallelogram comes from an eerie throne.</p>
       <p>The fighter is a polyester. The girlish accountant comes from a petrous grease. A mandolin is the man of a kayak. The step-brother of a novel becomes a breezy linen.</p>
       <p>Before examples, quails were only daughters. Though we assume the latter, the equinoxes could be said to resemble toilful beefs. In ancient times we can assume that any instance of a clutch can be construed as a ratite centimeter. The taloned flavor comes from an oaken mexico.</p>
 
-      <div class="zone grid combo">
-        <div id="zone-el-104" class="zone cap-width"></div>
-        <div id="zone-el-105" class="zone cap-width"></div>
-      </div>
+      <!-- <div class="zone grid combo"> -->
+      <!--   <div id="zone-el-104" class="zone cap-width"></div> -->
+      <!--   <div id="zone-el-105" class="zone cap-width"></div> -->
+      <!-- </div> -->
 
       <p>The destined employer comes from an elfish headline. Some assert that some modish bakers are thought of simply as prices. In modern times the amusement is an ounce. They were lost without the tenor phone that composed their james.</p>
       <div class="embed"></div>
       <p>A frockless crime without agreements is truly a virgo of scalelike channels. We can assume that any instance of an archaeology can be construed as a shaky waterfall. A piano is a soda from the right perspective. If this was somewhat unclear, those pins are nothing more than polands.</p>
 
-      <div id="zone-el-106" class="zone"></div>
+      <!-- <div id="zone-el-106" class="zone"></div> -->
 
       <p>A station can hardly be considered a purging pair of shorts without also being a rubber. The drug is an illegal. Before peonies, hacksaws were only frances. A draw can hardly be considered a wrathless save without also being a germany.</p>
       <p>Destined pumas show us how step-grandfathers can be toads. A raft is a tractor's anger. We know that the unsucked berry reveals itself as a knightly armchair to those who look. The toothbrushes could be said to resemble hornless deodorants.</p>
       <h3>Subhead</h3>
 
-      <div id="zone-el-107" class="zone"></div>
+      <!-- <div id="zone-el-107" class="zone"></div> -->
 
       <p>The textures could be said to resemble hairless flutes. Framed in a different way, a story of the spy is assumed to be a glowing kitchen. Authors often misinterpret the mexico as a nippy sociology, when in actuality it feels more like an antique scent. In modern times a song is a harmonica's slope.</p>
       <p>The zeitgeist contends that authors often misinterpret the tyvek as a prewar space, when in actuality it feels more like a prostyle pickle. The viewless shoulder reveals itself as a springing beret to those who look. The rudish tractor comes from a crumpled whorl. The zeitgeist contends that a root is the cucumber of an end.</p>
       <p>Their crush was, in this moment, an ireful snowman. Diffuse cellars show us how ronalds can be brasses. What we don't know for sure is whether or not the stormproof wool comes from a swampy literature. Some posit the jellied insect to be less than gaumless.</p>
 
-      <div id="zone-el-108" class="zone"></div>
+      <!-- <div id="zone-el-108" class="zone"></div> -->
 
       <p>The enhanced snowflake comes from a writhen surfboard. As far as we can estimate, a guardless silver is a digger of the mind. Unfortunately, that is wrong; on the contrary, they were lost without the spoutless stocking that composed their pressure. We know that one cannot separate causes from largest samurais.</p>
       <p>If this was somewhat unclear, authors often misinterpret the cable as a mistyped sock, when in actuality it feels more like a cattish tramp. Extending this logic, vibraphones are frizzly backs. If this was somewhat unclear, we can assume that any instance of a patch can be construed as a curly care. The literature would have us believe that a printless bread is not but an epoch.</p>
       <p>The literature would have us believe that an unthawed scooter is not but a perfume. We can assume that any instance of a price can be construed as a tarry shell. Extending this logic, the colleges could be said to resemble cancrine bases. A level is a country from the right perspective.</p>
-      <div id="zone-el-109" class="zone"></div>
+
+      <!-- <div id="zone-el-109" class="zone"></div> -->
+
       <p>In ancient times the oatmeal of a girdle becomes a peccant opinion. A defiled forehead is a dad of the mind. An undershirt is an extinct shirt. A creator is a scarf's segment.</p>
       <p>If this was somewhat unclear, a gimcrack unit's bacon comes with it the thought that the cutcha tsunami is a dinosaur. A nickel is a lavish needle. The zeitgeist contends that they were lost without the amort geography that composed their nigeria. The tubate impulse reveals itself as a timid chemistry to those who look.</p>
       <p>A rhythmic start is an angora of the mind. To be more specific, the literature would have us believe that a tryptic leek is not but a kick. A daffodil is a chair from the right perspective. The first groundless piano is, in its own way, a tip.</p>
-      <div id="zone-el-110" class="zone"></div>
+
+      <!-- <div id="zone-el-110" class="zone"></div> -->
+
       <p>A rotate sees a keyboard as a spoutless chard. A fire sees a balloon as a cleanly close. A rutabaga is a plaster's land. They were lost without the aidless granddaughter that composed their territory.</p>
       <p>A handicap is a trivalve mask. Bosker eyeliners show us how masks can be nickels. A marimba is a trochal sunshine. In ancient times those pastors are nothing more than bombs.</p>
       <p>Though we assume the latter, their pheasant was, in this moment, a crushing salesman. The first tardy language is, in its own way, a population. What we don't know for sure is whether or not the stifling tea reveals itself as a turbaned discovery to those who look. In modern times a confirmed era without ferries is truly a swordfish of tricorn jeeps.</p>
-      <div id="zone-el-111" class="zone"></div>
+
+      <!-- <div id="zone-el-111" class="zone"></div> -->
+
       <p>Their greece was, in this moment, a longwise shoulder. Silty sharks show us how partridges can be cormorants. A braggart authorization is an authorization of the mind. The shallow crate comes from a taloned pediatrician.</p>
       <p>The single is a psychiatrist. One cannot separate hardboards from cisted partridges. We know that a product is the hallway of a crab. A company is an instrument's spear.</p>
       <h3>Subhead</h3>
-      <div id="zone-el-112" class="zone"></div>
+
+      <!-- <div id="zone-el-112" class="zone"></div> -->
+
       <div class="embed"></div>
       <p>It's an undeniable fact, really; few can name a swainish ounce that isn't a freeing crook. The flexile rhinoceros comes from a canine pamphlet. A ball is a cabinet from the right perspective. In recent years, a character is the triangle of a punishment.</p>
       <p>Unfortunately, that is wrong; on the contrary, tsunamis are barebacked rains. Extending this logic, those archeologies are nothing more than dreams. Before margarets, bestsellers were only routers. A curbless help without men is truly a detective of wheyey drinks.</p>
-      <div id="zone-el-113" class="zone"></div>
+
+      <!-- <div id="zone-el-113" class="zone"></div> -->
+
       <p>The parrot is a fat. To be more specific, they were lost without the jumpy amusement that composed their camp. It's an undeniable fact, really; before ophthalmologists, waterfalls were only interactives. To be more specific, authors often misinterpret the fedelini as a witless titanium, when in actuality it feels more like a stinko frame.</p>
       <p>This is not to discredit the idea that a cocoa is the pisces of an actress. Their kenneth was, in this moment, a menseful harbor. The chill of a hydrant becomes a dressy cloud. This is not to discredit the idea that the first turdine tank is, in its own way, an advertisement.</p>
       <p>The first mucid helmet is, in its own way, a surname. They were lost without the bedded field that composed their kilometer. A duck is a syrup from the right perspective. A hardcover of the mail is assumed to be a relieved salmon.</p>

--- a/demo/story/index.html
+++ b/demo/story/index.html
@@ -53,14 +53,14 @@
       <p>The zeitgeist contends that a mile sees a hall as a tripping plasterboard. Framed in a different way, a noiseless note is a boundary of the mind. A mussy credit without flames is truly a alloy of android perfumes. It's an undeniable fact, really; before smashes, soldiers were only fragrances.</p>
       <p>Recent controversy aside, the spinach of a certification becomes an impure relation. Some unfought losses are thought of simply as emeries. To be more specific, a sugared day without lotions is truly a hardboard of gyral flags. A booted intestine without earths is truly a lentil of deposed pancreases.</p>
 
-      <!-- <div id="zone-el-101" class="zone" stnplayerkill="false" allowstnplayer="true"></div> -->
+      <div id="zone-el-101" class="zone" stnplayerkill="false" allowstnplayer="true"></div>
 
       <div class="embed"></div>
       <p>A varus foxglove is a hair of the mind. Some posit the wavy smell to be less than childing. We can assume that any instance of a ruth can be construed as a boarish evening. However, a drill can hardly be considered a sparing brazil without also being a chick.</p>
 
       <!-- <div class="zone grid combo"> -->
-      <!--   <div id="zone-el-102" class="zone cap-width"></div> -->
-      <!--   <div id="zone-el-103" class="zone cap-width"></div> -->
+        <div id="zone-el-102" class="zone cap-width"></div>
+        <div id="zone-el-103" class="zone cap-width"></div>
       <!-- </div> -->
 
       <p>Bones are mastless crooks. This could be, or perhaps a turgent professor's drive comes with it the thought that the spousal breath is a daisy. Far from the truth, the crossbred gender reveals itself as a tailored day to those who look. The fronded parallelogram comes from an eerie throne.</p>
@@ -68,45 +68,47 @@
       <p>Before examples, quails were only daughters. Though we assume the latter, the equinoxes could be said to resemble toilful beefs. In ancient times we can assume that any instance of a clutch can be construed as a ratite centimeter. The taloned flavor comes from an oaken mexico.</p>
 
       <!-- <div class="zone grid combo"> -->
-      <!--   <div id="zone-el-104" class="zone cap-width"></div> -->
-      <!--   <div id="zone-el-105" class="zone cap-width"></div> -->
+        <div id="zone-el-104" class="zone cap-width">
+          <p>This is a test</p>
+        </div>
+        <div id="zone-el-105" class="zone cap-width"></div>
       <!-- </div> -->
 
       <p>The destined employer comes from an elfish headline. Some assert that some modish bakers are thought of simply as prices. In modern times the amusement is an ounce. They were lost without the tenor phone that composed their james.</p>
       <div class="embed"></div>
       <p>A frockless crime without agreements is truly a virgo of scalelike channels. We can assume that any instance of an archaeology can be construed as a shaky waterfall. A piano is a soda from the right perspective. If this was somewhat unclear, those pins are nothing more than polands.</p>
 
-      <!-- <div id="zone-el-106" class="zone"></div> -->
+      <div id="zone-el-106" class="zone"></div>
 
       <p>A station can hardly be considered a purging pair of shorts without also being a rubber. The drug is an illegal. Before peonies, hacksaws were only frances. A draw can hardly be considered a wrathless save without also being a germany.</p>
       <p>Destined pumas show us how step-grandfathers can be toads. A raft is a tractor's anger. We know that the unsucked berry reveals itself as a knightly armchair to those who look. The toothbrushes could be said to resemble hornless deodorants.</p>
       <h3>Subhead</h3>
 
-      <!-- <div id="zone-el-107" class="zone"></div> -->
+      <div id="zone-el-107" class="zone"></div>
 
       <p>The textures could be said to resemble hairless flutes. Framed in a different way, a story of the spy is assumed to be a glowing kitchen. Authors often misinterpret the mexico as a nippy sociology, when in actuality it feels more like an antique scent. In modern times a song is a harmonica's slope.</p>
       <p>The zeitgeist contends that authors often misinterpret the tyvek as a prewar space, when in actuality it feels more like a prostyle pickle. The viewless shoulder reveals itself as a springing beret to those who look. The rudish tractor comes from a crumpled whorl. The zeitgeist contends that a root is the cucumber of an end.</p>
       <p>Their crush was, in this moment, an ireful snowman. Diffuse cellars show us how ronalds can be brasses. What we don't know for sure is whether or not the stormproof wool comes from a swampy literature. Some posit the jellied insect to be less than gaumless.</p>
 
-      <!-- <div id="zone-el-108" class="zone"></div> -->
+      <div id="zone-el-108" class="zone"></div>
 
       <p>The enhanced snowflake comes from a writhen surfboard. As far as we can estimate, a guardless silver is a digger of the mind. Unfortunately, that is wrong; on the contrary, they were lost without the spoutless stocking that composed their pressure. We know that one cannot separate causes from largest samurais.</p>
       <p>If this was somewhat unclear, authors often misinterpret the cable as a mistyped sock, when in actuality it feels more like a cattish tramp. Extending this logic, vibraphones are frizzly backs. If this was somewhat unclear, we can assume that any instance of a patch can be construed as a curly care. The literature would have us believe that a printless bread is not but an epoch.</p>
       <p>The literature would have us believe that an unthawed scooter is not but a perfume. We can assume that any instance of a price can be construed as a tarry shell. Extending this logic, the colleges could be said to resemble cancrine bases. A level is a country from the right perspective.</p>
 
-      <!-- <div id="zone-el-109" class="zone"></div> -->
+      <div id="zone-el-109" class="zone"></div>
 
       <p>In ancient times the oatmeal of a girdle becomes a peccant opinion. A defiled forehead is a dad of the mind. An undershirt is an extinct shirt. A creator is a scarf's segment.</p>
       <p>If this was somewhat unclear, a gimcrack unit's bacon comes with it the thought that the cutcha tsunami is a dinosaur. A nickel is a lavish needle. The zeitgeist contends that they were lost without the amort geography that composed their nigeria. The tubate impulse reveals itself as a timid chemistry to those who look.</p>
       <p>A rhythmic start is an angora of the mind. To be more specific, the literature would have us believe that a tryptic leek is not but a kick. A daffodil is a chair from the right perspective. The first groundless piano is, in its own way, a tip.</p>
 
-      <!-- <div id="zone-el-110" class="zone"></div> -->
+      <div id="zone-el-110" class="zone"></div>
 
       <p>A rotate sees a keyboard as a spoutless chard. A fire sees a balloon as a cleanly close. A rutabaga is a plaster's land. They were lost without the aidless granddaughter that composed their territory.</p>
       <p>A handicap is a trivalve mask. Bosker eyeliners show us how masks can be nickels. A marimba is a trochal sunshine. In ancient times those pastors are nothing more than bombs.</p>
       <p>Though we assume the latter, their pheasant was, in this moment, a crushing salesman. The first tardy language is, in its own way, a population. What we don't know for sure is whether or not the stifling tea reveals itself as a turbaned discovery to those who look. In modern times a confirmed era without ferries is truly a swordfish of tricorn jeeps.</p>
 
-      <!-- <div id="zone-el-111" class="zone"></div> -->
+      <div id="zone-el-111" class="zone"></div>
 
       <p>Their greece was, in this moment, a longwise shoulder. Silty sharks show us how partridges can be cormorants. A braggart authorization is an authorization of the mind. The shallow crate comes from a taloned pediatrician.</p>
       <p>The single is a psychiatrist. One cannot separate hardboards from cisted partridges. We know that a product is the hallway of a crab. A company is an instrument's spear.</p>

--- a/index.js
+++ b/index.js
@@ -24,7 +24,9 @@ async function distributeZones(locker) {
   }
 
   // Add the communication bridge 
-  locker.getYozonsLocker("zones").changes = zones.changes;
+  // locker.getYozonsLocker("zones").changes = zones.changes;
+  window.mi = window.mi || {};
+  window.mi.zones = zones.getPublicAPI();
 
   // Give the performance team a promise
   return new Promise((resolve, reject) => {

--- a/index.js
+++ b/index.js
@@ -24,7 +24,6 @@ async function distributeZones(locker) {
   }
 
   // Add the communication bridge 
-  // locker.getYozonsLocker("zones").changes = zones.changes;
   window.mi = window.mi || {};
   window.mi.zones = zones.getPublicAPI();
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -79,7 +79,7 @@ export function load(url) {
         remove = false,
         classList = [],
         style = "",
-        type = "ad",
+        type = "",
         tracking = false,
         cue = false,
         zephr = false,

--- a/lib/config.js
+++ b/lib/config.js
@@ -57,7 +57,7 @@ export function load(url) {
       }
 
       zones.setCadence(cadence);
-      zones.createStoryZones();
+      // zones.createStoryZones();
     }
 
     // Ignore these WPS zones
@@ -71,17 +71,19 @@ export function load(url) {
     set.forEach( config => {
       const { 
         id, 
-        filters = [], 
+        filters = {}, 
         vip = undefined, 
         position = "beforebegin",
         before = undefined, 
         after = undefined,
+        remove = false,
         classList = [],
         type = "ad",
         tracking = false,
-        cue,
-        zephr,
-        targeting
+        cue = false,
+        zephr = false,
+        loading = "lazy",
+        targeting = {}
       } = config;
 
       // Make the zone 
@@ -92,27 +94,27 @@ export function load(url) {
          * Placement options
          */
 
-        if(vip) {
-          zone.vip = document.querySelector(config.vip);
+        if(remove) {
+          zone.remove();
+        }
+        else if(vip) {
+          zone.vip = document.querySelector(vip);
         } 
         else if(before) {
-          zone.before(config.before);
+          zone.before(before);
         }
         else if(after) {
-          zone.after(config.after);
+          zone.after(after);
         } 
 
         /*
          * Output options
          */
 
-        if(targeting) {
-          zone.gam(targeting);
-        }
-
         // CUE connection
-        else if(cue) {
-          zone.cue(cue);
+        if(cue) {
+          // zone.cue(cue);
+          zone.hopper.set("cue", cue);
         }
 
         // Zephr connection
@@ -128,6 +130,11 @@ export function load(url) {
           zone.zephr(feature);
         }
 
+        // Default to GAM
+        else {
+          zone.gam(targeting);
+        }
+
         /*
          * Remaining configs
          */
@@ -135,6 +142,7 @@ export function load(url) {
         zone.position = position;
         zone.classList.add(...classList)
         zone.type = type;
+        zone.loading = loading;
         zone.tracking = tracking;
       }
     });

--- a/lib/config.js
+++ b/lib/config.js
@@ -83,7 +83,6 @@ export function load(url) {
         tracking = false,
         cue = false,
         zephr = false,
-        lazy = true,
         targeting = {}
       } = config;
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -41,8 +41,8 @@ export function load(url) {
       wps.forEach(ele => new zones.Zone(ele.id));
     }
 
-    // Generate story zones
-    if(data.cadence && zones.isStoryPage()) {
+    // Story page specifics
+    if(zones.isStoryPage()) {
       let cadence;
 
       switch(true) {
@@ -78,11 +78,12 @@ export function load(url) {
         after = undefined,
         remove = false,
         classList = [],
+        style = "",
         type = "ad",
         tracking = false,
         cue = false,
         zephr = false,
-        loading = "lazy",
+        lazy = true,
         targeting = {}
       } = config;
 
@@ -108,17 +109,16 @@ export function load(url) {
         } 
 
         /*
-         * Output options
+         * Storage options
          */
 
         // CUE connection
         if(cue) {
-          // zone.cue(cue);
-          zone.hopper.set("cue", cue);
+          zone.hopper.set("cue", cue)
         }
 
         // Zephr connection
-        else if(zephr) {
+        if(zephr) {
           const { feature, dataset } = zephr;
 
           if(Array.isArray(dataset)) {
@@ -127,22 +127,17 @@ export function load(url) {
             });
           }
 
-          zone.zephr(feature);
-        }
-
-        // Default to GAM
-        else {
-          zone.gam(targeting);
+          zone.hopper.set("zephr", feature);
         }
 
         /*
          * Remaining configs
          */
 
-        zone.position = position;
-        zone.classList.add(...classList)
         zone.type = type;
-        zone.loading = loading;
+        zone.position = position;
+        zone.classList.add(...classList);
+        zone.style.cssText = style;
         zone.tracking = tracking;
       }
     });

--- a/lib/zones.js
+++ b/lib/zones.js
@@ -84,6 +84,18 @@ export class Zone {
     }
   }
 
+  /**
+   * Getter/Setter for the type
+   */
+
+  get type() {
+    return this.dataset.type;
+  }
+
+  set type(val) {
+    this.dataset.type = val;
+  }
+
   /*
    * Getters for element attributes
    */

--- a/lib/zones.js
+++ b/lib/zones.js
@@ -6,7 +6,7 @@ let locker, cadence;
 let map = new Map();
 
 const configs = new Map();
-const fragment = new DocumentFragment();
+const backup = new DocumentFragment();
 const loadObserver = new IntersectionObserver(handleLoad, { rootMargin: "500px" });
 const trackingObserver = new IntersectionObserver(handleTracking, { threshold: 0.25 });
 
@@ -41,7 +41,7 @@ export class Zone {
   }
 
   set id(val) {
-    let zone = document.getElementById(val) || fragment.getElementById(val);
+    let zone = document.getElementById(val) || backup.getElementById(val);
 
     if(!zone) {
       zone = document.createElement("div");
@@ -49,8 +49,8 @@ export class Zone {
     }
 
     this.element = zone;
-    this.element.classList.add("zone");
-    this.element.fragment = new DocumentFragment();
+    this.classList.add("zone");
+    this.fragment = new DocumentFragment();
 
     // Add this zone to the map
     map.set(val, this);
@@ -66,6 +66,18 @@ export class Zone {
 
   set tracking(val) {
     this.element.dataset.tracking = val;
+  }
+
+  /*
+   * Getter/Setter for the zone fragment
+   */
+
+  get fragment() {
+    return this.element.fragment;
+  }
+
+  set fragment(v) {
+    this.element.fragment = v;
   }
 
   /*
@@ -108,7 +120,7 @@ export class Zone {
     // Create the range including script tags
     if(payload) {
       const range = document.createRange().createContextualFragment(payload);
-      this.element.fragment.append(range);
+      this.fragment.append(range);
     } else {
       this.log("Zephr paylod was empty");
     }
@@ -129,7 +141,7 @@ export class Zone {
 
     if(payload) {
       const range = document.createRange().createContextualFragment(payload);
-      this.element.fragment.append(range);
+      this.fragment.append(range);
     } else {
       this.log("CUE payload was empty");
     }
@@ -142,13 +154,15 @@ export class Zone {
 
   async gam(targeting) {
     const defaults = {
-      "memo": "default"
+      atf: "n",
+      pkg: "a"
     }
     
     const payload = {...defaults, ...targeting};
-    const tag = locker.createAdTag(payload);
+    const ads = locker.getAPI("ads");
+    const tag = ads.createAdTag(payload);
 
-    this.element.fragment.append(tag);
+    this.fragment.append(tag);
   }
 
   /*
@@ -181,11 +195,8 @@ export class Zone {
       vip.insertAdjacentElement(position || "beforebegin", this.element);
 
       // If no fragment, make it an ad
-      if(this.element.fragment.childElementCount == 0) {
-        this.gam({ 
-          atf: false,
-          memo: "default" 
-        });
+      if(!this.fragment.childElementCount) {
+        this.gam();
       }
 
       // Messaging
@@ -254,6 +265,14 @@ export class Zone {
   log(msg) {
     log(this.id, msg);
   }
+}
+
+/*
+ * Exports the public API limited set
+ */
+
+export function getPublicAPI() {
+  return { changes };
 }
 
 /*
@@ -382,7 +401,7 @@ export function remove(id) {
   let entry = map.get(id);
 
   if(entry) {
-    fragment.append(entry.element);
+    backup.append(entry.element);
     log(id, "zone removed");
   }
 
@@ -519,7 +538,6 @@ function handleLoad(entries, observer) {
       let e = entry.target;
 
       // Move the fragment into position
-      // console.log(e.id, e.fragment);
       e.append(e.fragment);
 
       // Build the load event

--- a/lib/zones.js
+++ b/lib/zones.js
@@ -7,8 +7,9 @@ let map = new Map();
 
 const configs = new Map();
 const backup = new DocumentFragment();
-const loadObserver = new IntersectionObserver(handleLoad, { rootMargin: "500px" });
-const trackingObserver = new IntersectionObserver(handleTracking, { threshold: 0.25 });
+const io = new IntersectionObserver(handleIntersection, { rootMargin: "500px" });
+const to = new IntersectionObserver(handleTracking, { threshold: 0.25 });
+const mo = new MutationObserver(handleFragment);
 
 // Changes map
 export const changes = new Map();
@@ -18,7 +19,6 @@ export const changes = new Map();
  */
 
 export class Zone {
-
   /*
    * Zone constructor
    */
@@ -48,12 +48,17 @@ export class Zone {
       zone.id = val;
     }
 
+    // Set up the fragment
     this.element = zone;
-    this.classList.add("zone");
-    this.fragment = new DocumentFragment();
+    this.element.hopper = new Map();
+    this.element.fragment = new DocumentFragment();
+    debugger;
 
     // Add this zone to the map
     map.set(val, this);
+
+    // Deprecated
+    // this.classList.add("zone");
   }
 
   /*
@@ -69,15 +74,26 @@ export class Zone {
   }
 
   /*
-   * Getter/Setter for the zone fragment
+   * Functions for working with the fragment
    */
 
-  get fragment() {
-    return this.element.fragment;
-  }
+  // get empty() {
+  //   return this.element.fragment.childElementCount < 1;
+  // }
+  
+  /*
+   * Appends dom/string to the fragment
+   * @param payload {mixed} the element or string to inject
+   */
 
-  set fragment(v) {
-    this.element.fragment = v;
+  append(payload) {
+    console.log(this);
+    // if(payload instanceof HTMLElement) {
+    //   this.element.fragment.append(payload);
+    // } else {
+      let range = document.createRange().createContextualFragment(payload);
+      this.element.fragment.append(range)
+    // }
   }
 
   /*
@@ -117,10 +133,8 @@ export class Zone {
     const response = await req.json();
     const payload = response.outputValue;
     
-    // Create the range including script tags
     if(payload) {
-      const range = document.createRange().createContextualFragment(payload);
-      this.fragment.append(range);
+      this.append(payload);
     } else {
       this.log("Zephr paylod was empty");
     }
@@ -140,8 +154,7 @@ export class Zone {
     const payload = response.content;
 
     if(payload) {
-      const range = document.createRange().createContextualFragment(payload);
-      this.fragment.append(range);
+      this.append(payload);
     } else {
       this.log("CUE payload was empty");
     }
@@ -162,7 +175,7 @@ export class Zone {
     const ads = locker.getAPI("ads");
     const tag = ads.createAdTag(payload);
 
-    this.fragment.append(tag);
+    this.append(tag);
   }
 
   /*
@@ -195,20 +208,20 @@ export class Zone {
       vip.insertAdjacentElement(position || "beforebegin", this.element);
 
       // If no fragment, make it an ad
-      if(!this.fragment.childElementCount) {
-        this.gam();
-      }
+      // if(this.empty) {
+      //   this.gam();
+      // }
 
       // Messaging
       this.dataset.distributed = true;
       this.log(this.msg || "zone created");
 
       // Observer for performance team
-      loadObserver.observe(this.element);
+      io.observe(this.element);
 
       // Tracking observer
       if(this.tracking) {
-        trackingObserver.observe(this.element);
+        to.observe(this.element);
       }
     }
   }
@@ -532,27 +545,33 @@ export function render() {
  * Intersection callback
  */
 
-function handleLoad(entries, observer) {
+function handleIntersection(entries, observer) {
   entries.forEach((entry) => {
     if(entry.isIntersecting) {
       let e = entry.target;
+      let ready = e.fragment.childElementCount;
 
       // Move the fragment into position
-      e.append(e.fragment);
-
-      // Build the load event
-      const intersectionEvent = new CustomEvent("zone", {
-        detail: {
-          id: e.id
-        }
-      });
-
-      // Send it
-      window.dispatchEvent(intersectionEvent);
+      if(ready) {
+        e.append(e.fragment);
+      } else {
+        mo.observe(e.fragment, { childList: true });
+      }
 
       // Only do this once
-      loadObserver.unobserve(e);
+      observer.unobserve(e);
     }
+  });
+}
+
+/*
+ * Fragment mutation callback
+ */
+
+function handleFragment(entries) {
+  entries.forEach(entry => {
+    console.log(entry.target);
+    // entry.target.zone.append(entry.target);
   });
 }
 
@@ -580,7 +599,7 @@ function handleTracking(entries, observer) {
       window.dispatchEvent(trackEvent);
 
       // Only do this once
-      trackingObserver.unobserve(entry.target);
+      observer.unobserve(entry.target);
     }
   });
 }

--- a/lib/zones.js
+++ b/lib/zones.js
@@ -146,8 +146,8 @@ export class Zone {
    */
 
   async cue(id) {
-    const market = locker.getConfig("marketInfo.domain");
-    const endpoint = `https://www.${market}.com/webapi-public/v2/content/${id}`
+    const domain = locker.getConfig("domainName");
+    const endpoint = `https://${domain}/webapi-public/v2/content/${id}`
 
     const req = await fetch(endpoint);
     const response = await req.json();

--- a/lib/zones.js
+++ b/lib/zones.js
@@ -9,7 +9,6 @@ const configs = new Map();
 const backup = new DocumentFragment();
 const io = new IntersectionObserver(handleIntersection, { rootMargin: "500px" });
 const to = new IntersectionObserver(handleTracking, { threshold: 0.25 });
-const mo = new MutationObserver(handleFragment);
 
 // Changes map
 export const changes = new Map();
@@ -30,6 +29,7 @@ export class Zone {
 
     this.id = id;
     this.vip = vip;
+    this.hopper = new Map();
   }
 
   /*
@@ -41,24 +41,21 @@ export class Zone {
   }
 
   set id(val) {
-    let zone = document.getElementById(val) || backup.getElementById(val);
+    let ele = document.getElementById(val) || backup.getElementById(val);
 
-    if(!zone) {
-      zone = document.createElement("div");
-      zone.id = val;
+    if(!ele) {
+      ele = document.createElement("div");
+      ele.id = val;
     }
 
-    // Set up the fragment
-    this.element = zone;
-    this.element.hopper = new Map();
-    this.element.fragment = new DocumentFragment();
-    debugger;
+    // Connect the element
+    this.element = ele;
 
     // Add this zone to the map
     map.set(val, this);
 
-    // Deprecated
-    // this.classList.add("zone");
+    // Add the zone class for SDS (deprecated)
+    this.classList.add("zone");
   }
 
   /*
@@ -74,26 +71,17 @@ export class Zone {
   }
 
   /*
-   * Functions for working with the fragment
-   */
-
-  // get empty() {
-  //   return this.element.fragment.childElementCount < 1;
-  // }
-  
-  /*
-   * Appends dom/string to the fragment
-   * @param payload {mixed} the element or string to inject
+   * Appends dom/string to the element
+   * @param payload {element|string} the element or string to inject
    */
 
   append(payload) {
-    console.log(this);
-    // if(payload instanceof HTMLElement) {
-    //   this.element.fragment.append(payload);
-    // } else {
+    if(payload instanceof HTMLElement) {
+      this.element.append(payload);
+    } else {
       let range = document.createRange().createContextualFragment(payload);
-      this.element.fragment.append(range)
-    // }
+      this.element.append(range)
+    }
   }
 
   /*
@@ -146,8 +134,8 @@ export class Zone {
    */
 
   async cue(id) {
-    const market = locker.getConfig("domainName");
-    const endpoint = `https://${market}/webapi-public/v2/content/${id}`
+    const market = locker.getConfig("marketInfo.domain");
+    const endpoint = `https://www.${market}.com/webapi-public/v2/content/${id}`
 
     const req = await fetch(endpoint);
     const response = await req.json();
@@ -161,11 +149,11 @@ export class Zone {
   }
 
   /*
-   * GAM ad functionality
+   * Ad functionality
    * @param targeting {object} the targeting string for the ad
    */
 
-  async gam(targeting) {
+  async ad(targeting) {
     const defaults = {
       atf: "n",
       pkg: "a"
@@ -206,11 +194,6 @@ export class Zone {
     } else {
       // Insert the element
       vip.insertAdjacentElement(position || "beforebegin", this.element);
-
-      // If no fragment, make it an ad
-      // if(this.empty) {
-      //   this.gam();
-      // }
 
       // Messaging
       this.dataset.distributed = true;
@@ -506,6 +489,7 @@ export function createStoryZones() {
 
   for(let i = 1; i <= total; i++) {
     const zone = new Zone(`zone-el-${100 + i}`);
+    zone.ad();
   }
 }
 
@@ -549,29 +533,15 @@ function handleIntersection(entries, observer) {
   entries.forEach((entry) => {
     if(entry.isIntersecting) {
       let e = entry.target;
-      let ready = e.fragment.childElementCount;
-
-      // Move the fragment into position
-      if(ready) {
-        e.append(e.fragment);
-      } else {
-        mo.observe(e.fragment, { childList: true });
-      }
+      let zone = map.get(e.id);
+      
+      zone.hopper.forEach((value, key) => {
+        zone[key](value);
+      });
 
       // Only do this once
       observer.unobserve(e);
     }
-  });
-}
-
-/*
- * Fragment mutation callback
- */
-
-function handleFragment(entries) {
-  entries.forEach(entry => {
-    console.log(entry.target);
-    // entry.target.zone.append(entry.target);
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcclatchy/zones",
-  "version": "1.7.0",
+  "version": "1.8.1",
   "description": "A Yozons extension to dynamically distribute or re-distribute zones on the websites.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### What does this PR do?

It includes the simplified config structure and preliminary code to generate ad units from the extension. The ad functionality is not enabled. It also adds some additional functionality.

+ We can now set the position for the injection point. Values will be passed directly into the `insertAdjacentHTML()` function as the first argument, and should therefore be one of the supported values.
+ `style` is now hooked up and configurable using a standard inline CSS string
+ `type` is now configurable and will be passed to the `data-type` attribute. We will use this later for ads, and SDS also has values for this attribute. It's an open string, but current values are "ad" and "editorial".
+ cue and zephr payloads are lazy-loaded by an intersection observer. HTL ad tags, when we implement those, are already lazy loaded elsewhere.

### How to test

I'm including a full overrides folder with a netdale build and all config files for www.idahostatesman.com. To test other markets, simply copy the whole directory into the appropriate domain in your overrides folder. I ran through most of the zones already, and used kentucky.com, kansas.com, and thestate.com.

[zones-overrides.zip](https://github.com/mcclatchy/zones/files/13055911/zones-overrides.zip)
