### PR TITLE
bringing back the amazon-prime-day card for black friday

### DIFF
--- a/config/section.json
+++ b/config/section.json
@@ -7,6 +7,15 @@
       "filters": {
         "subscriber": false
       }
+    },
+    {
+      "id": "zone-amazon-prime",
+      "cue": 277182383,
+      "classList": ["three-columns"],
+      "vip": "#secondary-story-4",
+      "filters": {
+        "marketInfo.sourcelevel": "mcpshopping"
+      }
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Bringing back the Amazone Prime Day card for Black Friday sales. This zone only applies to shopping section pages.

Note: there is a sister PR in the cards repo to update the design a bit and that is also included in the overrides file.

## What it should look like
![Screenshot 2023-11-16 2 57 43 PM](https://github.com/mcclatchy/zones/assets/198070/3ad9ceb8-cd53-4473-8277-90434fb3280e)

## Overrides
[black-friday-overrides.zip](https://github.com/mcclatchy/zones/files/13383412/black-friday-overrides.zip)
