### PR TITLE
PEX-63: removing amazon prime section zone

### DIFF
--- a/config/section.json
+++ b/config/section.json
@@ -7,15 +7,6 @@
       "filters": {
         "subscriber": false
       }
-    },
-    {
-      "id": "zone-amazon-prime",
-      "cue": 277182383,
-      "classList": ["three-columns"],
-      "vip": "#secondary-story-4",
-      "filters": {
-        "marketInfo.sourcelevel": "mcpshopping"
-      }
     }
   ]
 }


### PR DESCRIPTION
Chase asked for this one to come down. Simple config removal in the `section.json` file.