### PR TITLE
PEX-62: putting Taboola recommendations on all stories

### DIFF
--- a/config/story.json
+++ b/config/story.json
@@ -11,9 +11,6 @@
       "id": "zone-taboola-recommendations",
       "after": "zone-el-101",
       "tracking": true,
-      "filters": {
-        "zone.taboolaRecommendations": true
-      },
       "zephr": {
         "feature": "zone-taboola-recommendations",
         "dataset": ["dma"]


### PR DESCRIPTION
## What does this one do?

Cynthia asked to put the Taboola recommendations zone on all stories for all markets. This simply removes the filter in the config.