### PR TITLE
ensuring mi.zones isn't clobbered

### DIFF
--- a/demo/story/index.html
+++ b/demo/story/index.html
@@ -15,6 +15,12 @@
     <link rel="stylesheet" href="/demo/demo.css">
 
     <script type="module">
+      window.mi = {
+        zones: {
+          test: "performance"
+        }
+      }
+
       import locker from "../locker.js";
       import distributeZones from "/index.js";
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ async function distributeZones(locker) {
 
   // Add the communication bridge 
   window.mi = window.mi || {};
-  window.mi.zones = zones.getPublicAPI();
+  window.mi.zones = window.mi.zones || {};
+  window.mi.zones = Object.assign(window.mi.zones, zones.getPublicAPI());
 
   // Give the performance team a promise
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## What does this PR do?

Joe W. identified an issue where we were clobbering the `window.mi.zones` object. We are moving in the direction of having the extension manage all data associated with zones, but I jumped the gun a bit and Joe still needs this object. This change simply ensures if there is already a `window.mi.zones` object in play to extend it.

## How to test

I've changed the [story demo page](http://localhost:3000/demo/story/) to set the `window.mi` object up prior to loading the extension. You can see the additional `test: "performance"` property/value in devtools.