### PR TITLE
Remove the SI Tickets widget (awaiting SI updates)

### DIFF
--- a/config/story.json
+++ b/config/story.json
@@ -17,14 +17,6 @@
       }
     },
     {
-      "id": "zone-si-tickets",
-      "after": "zone-el-101",
-      "cue": 278143207,
-      "filters": {
-        "zone.siTickets": true
-      }
-    },
-    {
       "id": "zone-gamecocks-nav",
       "vip": ".story-body",
       "cue": 278142507,

--- a/config/story.json
+++ b/config/story.json
@@ -8,6 +8,18 @@
   },
   "zones": [
     {
+      "id": "zone-taboola-recommendations",
+      "after": "zone-el-101",
+      "tracking": true,      
+      "filters": {
+        "zone.taboolaRecommendations": true
+      },
+      "zephr": {
+        "feature": "zone-taboola-recommendations",
+        "dataset": ["dma"]
+      }
+    },
+    {
       "id": "zone-gamecocks-nav",
       "vip": ".story-body",
       "cue": 278142507,

--- a/config/story.json
+++ b/config/story.json
@@ -8,15 +8,6 @@
   },
   "zones": [
     {
-      "id": "zone-taboola-recommendations",
-      "after": "zone-el-101",
-      "tracking": true,
-      "zephr": {
-        "feature": "zone-taboola-recommendations",
-        "dataset": ["dma"]
-      }
-    },
-    {
       "id": "zone-gamecocks-nav",
       "vip": ".story-body",
       "cue": 278142507,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcclatchy/zones",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "A Yozons extension to dynamically distribute or re-distribute zones on the websites.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
This removes the Sports Illustrated ticket zone from the article config. 

We're removing it because football season is over and SI hasn't yet provided reliable API endpoints for basketball events. We'll reactivate this zone once they provide functional performer IDs for additional sports. 

[Remind me if this needs a version bump of some sort. The change is config-only so I didn't add it to the PR.]