### PR TITLE
PE-74: adding the ads allowed config value

### DIFF
--- a/config/story.json
+++ b/config/story.json
@@ -12,7 +12,7 @@
       "after": "zone-el-101",
       "tracking": true,      
       "filters": {
-        "marketInfo.allow_ads": true
+        "ads": true
       },
       "zephr": {
         "feature": "zone-taboola-recommendations",

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ async function distributeZones(locker) {
   zones.setLocker(locker);
   zones.setConfig("subscriber", subscriber);
   zones.setConfig("dma", subscriber ? true : await locker.user.isInDMA());
+  zones.setConfig("ads", locker.getYozonsLocker("core").areAdsAllowed());
 
   // Config files 
   if(!locker.config) {


### PR DESCRIPTION
## What does this PR do?

It adds the value of `locker.getYozonsLocker("core").areAdsAllowed()` to the config Set, just like the DMA function.

_Note: there is an updated `story.json` file to use this in the attached overrides zip._

## How to test

Unzip the attached overrides folder to your local setup and check out any miamiherald.com article. For dev, I was using this one: https://www.miamiherald.com/sports/nfl/miami-dolphins/article282580408.html

[PE-74-overrides.zip](https://github.com/mcclatchy/zones/files/13641875/PE-74-overrides.zip)

We are not responsible for the look on this one. Taboola renders it and it should look like the attached screenshot.

---

![taboola-recirc-sample](https://github.com/mcclatchy/zones/assets/198070/a794b0eb-6882-4b8b-8a99-6c72a28a0d3f)
