### PR TITLE
PE-88: adding taboola recs back

### DIFF
--- a/config/story.json
+++ b/config/story.json
@@ -38,6 +38,18 @@
       "filters": {
         "subscriber": true
       }
+    },
+    {
+      "id": "zone-taboola-recommendations",
+      "after": "zone-el-101",
+      "tracking": true,      
+      "filters": {
+        "ads": true
+      },
+      "zephr": {
+        "feature": "zone-taboola-recommendations",
+        "dataset": ["dma"]
+      }
     }
   ]
 }


### PR DESCRIPTION
Could you give this a quick once-over and make sure the element is rendering correctly for you. We've been going back and forth with Taboola for a few weeks and it looks like they've got it squared away. Just download the overrides and go to this story (or any other long enough for two zones).

https://www.kansascity.com/sports/spt-columns-blogs/sam-mcdowell/article284558505.html

[PE-88-overrides.zip](https://github.com/mcclatchy/zones/files/14027120/PE-88-overrides.zip)

## Screenshot

Here's a screenshot of what you should see, though you will have different stories.

![Screenshot 2024-01-23 10 18 31 AM](https://github.com/mcclatchy/zones/assets/198070/e2185ea1-944d-447a-9bb3-ee1e7085fe8f)

