### PR TITLE
Remove eedition/sections promo from homepage config

### DIFF
--- a/config/homepage.json
+++ b/config/homepage.json
@@ -40,14 +40,6 @@
       "filters": {
         "zone.eeditionPromoGames": true
       }
-    },
-    {
-      "id": "zone-eedition-promo-sections",
-      "vip": "#secondary-story-3",
-      "cue": 284301373,
-      "filters": {
-        "zone.eeditionPromoSections": true
-      }
     }
   ]
 }


### PR DESCRIPTION
We've been asked to enable the games/puzzles version of the eedition promo on all sites – this PR removes the alternative "sections" version of the eedition promo from the homepage config. 

This change should be deployed before the section parameter for the "games" version (`mi.pageInfo.zone.eeditionPromoGames`) is added across the board.