### PR TITLE
adding GDC betting digest to story.json

### DIFF
--- a/config/story.json
+++ b/config/story.json
@@ -38,6 +38,17 @@
       "filters": {
         "subscriber": true
       }
+    },
+    {
+      "id": "zone-gdc-betting-digest",
+      "after": "zone-el-101",
+      "zephr": {
+        "feature": "zone-gdc-betting-digest",
+        "dataset": ["marketInfo.domain"]
+      },
+      "filters": {
+        "zone.gdcStoryDigest": true
+      }
     }
   ]
 }


### PR DESCRIPTION
## Overview

This simply adds a GDC betting digest to the story.json config file. Check [PE-100](https://mcclatchy.atlassian.net/browse/PE-100?atlOrigin=eyJpIjoiM2Q4NzJlM2NlNDNjNDM1OWFlOTE2YjE3ZTVhZmJlYjQiLCJwIjoiaiJ9) for details about Zephr and the payload.

The overrides include a pageInfo config change on a [specific aricle](https://www.kansascity.com/sports/college/big-12/kansas-state/article284919872.html), so please use the same link to test.

## Screenshot

![gdc-in-article-digest](https://github.com/mcclatchy/zones/assets/198070/0308617c-06cf-4e9b-84bb-26be48f6bec0)

## Overrides

[pe-100-overrides.zip](https://github.com/mcclatchy/zones/files/14127389/pe-100-overrides.zip)
