### PR TITLE
DSP check

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,12 +7,22 @@ import * as config from "./lib/config.js";
 import * as story from "./lib/story.js";
 
 async function distributeZones(locker) {
-  const subscriber = locker.user.isSubscriber();
+  let subscriber, dma;
+
+  // DSP limited to production domains
+  try {
+    subscriber = locker.user.isSubscriber();
+    dma = await locker.user.isInDMA();
+  } catch(e) {
+    subscriber = false;
+    dma = false
+    console.warn("DSP is not available");
+  }
 
   // Setup
   zones.setLocker(locker);
   zones.setConfig("subscriber", subscriber);
-  zones.setConfig("dma", subscriber ? true : await locker.user.isInDMA());
+  zones.setConfig("dma", subscriber ? true : dma);
   zones.setConfig("ads", locker.getYozonsLocker("core").areAdsAllowed());
 
   // Config files 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcclatchy/zones",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "A Yozons extension to dynamically distribute or re-distribute zones on the websites.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
# Overview 

CORS settings for the new DSP code prevents it from responding in local environments. This change wraps the Yozons functions that use the `locker.user` property in a try/catch statement. Subscriber and DMA status both default to false on an error.

## Testing

I had to do a  full Yozons build this time, so the overrides for www.kansascity.com are attached. Simply unzip into your overrides folder and you should be good to go. There was a restructuring, so the zones codebase is now built into the `zones.xxx.js` file, rather than the `netdale.xxx.js` file. For my testing, I added a breakpoint directly after the changed portion to ensure the file ran and the `subscriber` and `dma` variables are correct.

This is not a very big change, either. If you weren't inclined to do this full testing and rather ensure the syntax is correct I wouldn't blame ya.

[dsp-check-overrides.zip](https://github.com/mcclatchy/zones/files/14780281/dsp-check-overrides.zip)
