### PR TITLE
PE-127 disable VIP for OOM readers

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -57,7 +57,6 @@ export function load(url) {
       }
 
       zones.setCadence(cadence);
-      // zones.createStoryZones();
     }
 
     // Ignore these WPS zones

--- a/lib/zones.js
+++ b/lib/zones.js
@@ -459,35 +459,44 @@ export function track(key, msg, flush = true) {
 /*
  * Identifies valid insertion points for zones in story bodies
  * @returns {array} all valid paragraph elements
+ *
+ * NEW
+ * ---
+ * PE-127 disables vip functionality for OOM readers
  */
 
 export function getValidInsertionPoints() {
-  const df = new DocumentFragment();
   const story = document.querySelector(".story-body");
-  const grafs = [...story.querySelectorAll(":scope > p")];
 
-  // Make a copy of the story nodes
-  df.append(story.cloneNode(true));
+  if(getConfig("dma")) {
+    const df = new DocumentFragment();
+    const grafs = [...story.querySelectorAll(":scope > p")];
 
-  // Clean zones out of the copy
-  df.querySelectorAll("[id^=zone-], .zone").forEach(ele => ele.remove());
+    // Make a copy of the story nodes
+    df.append(story.cloneNode(true));
 
-  // Make a boolean map for each paragraph
-  const clones = [...df.querySelectorAll(".story-body > p")];
-  const map = clones.map((p, i) => { 
-    let prev = p.previousElementSibling;
+    // Clean zones out of the copy
+    df.querySelectorAll("[id^=zone-], .zone").forEach(ele => ele.remove());
 
-    if(i == 0) return true;
-    if(p.textContent.length < 100) return false;
-    if(prev && prev.nodeName != "P") return false;
+    // Make a boolean map for each paragraph
+    const clones = [...df.querySelectorAll(".story-body > p")];
+    const map = clones.map((p, i) => { 
+      let prev = p.previousElementSibling;
 
-    return true;
-  });
+      if(i == 0) return true;
+      if(p.textContent.length < 100) return false;
+      if(prev && prev.nodeName != "P") return false;
 
-  // Return a filtered array of the real ones
-  return grafs.filter((p, i) => {
-    return map[i] === true;
-  });
+      return true;
+    });
+
+    // Return a filtered array of the real ones
+    return grafs.filter((p, i) => {
+      return map[i] === true;
+    });
+  } else {
+    return Array.from(story.querySelectorAll(":scope > p, :scope > figure, :scope > .embed-infographic"));
+  }
 }
 
 /*


### PR DESCRIPTION
This alters the VIP rules for out of market non-subs by including paragraphs, media element and embeds and removing the validity checks. We're doing this to make up for a revenue shortage.

I'm including Yozons overrides and also this [miamiherald article](https://www.miamiherald.com/news/state/florida/article287351770.html), where I've altered the `pageInfo` object to disable the paywall. You should be out of market and can log in to see both experiences.

[PE-127-overrides.zip](https://github.com/mcclatchy/zones/files/15237848/PE-127-overrides.zip)
