### PR TITLE
PE-215 phasing out zones

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,10 @@ import * as config from "./lib/config.js";
 import * as story from "./lib/story.js";
 
 async function distributeZones(locker) {
-  // Using a section config to scale from this repo to experiences
-  // if(locker.getConfig("zones") != "experiences") {
+  // Using a section config to switch from this repo to experiences
+  if(locker.getConfig("zones") == "experiences") {
+    return Promise.resolve("zones-loaded");
+  } else {
     let subscriber, dma;
 
     // DSP limited to production domains
@@ -68,7 +70,7 @@ async function distributeZones(locker) {
         resolve("zones-loaded")
       });
     });
-  // }
+  }
 }
 
 export default distributeZones;

--- a/index.js
+++ b/index.js
@@ -7,6 +7,12 @@ import * as config from "./lib/config.js";
 import * as story from "./lib/story.js";
 
 async function distributeZones(locker) {
+  // Using a section config to scale from this repo to experiences
+  if(locker.getConfig("zones") == "experiences") {
+    return Promise.resolve("zones-loaded");
+  }
+
+  // Proceed as normal
   let subscriber, dma;
 
   // DSP limited to production domains

--- a/index.js
+++ b/index.js
@@ -8,70 +8,67 @@ import * as story from "./lib/story.js";
 
 async function distributeZones(locker) {
   // Using a section config to scale from this repo to experiences
-  if(locker.getConfig("zones") == "experiences") {
-    return Promise.resolve("zones-loaded");
-  }
+  if(locker.getConfig("zones") != "experiences") {
+    let subscriber, dma;
 
-  // Proceed as normal
-  let subscriber, dma;
-
-  // DSP limited to production domains
-  try {
-    subscriber = locker.user.isSubscriber();
-    dma = await locker.user.isInDMA();
-  } catch(e) {
-    subscriber = false;
-    dma = false
-    console.warn("DSP is not available");
-  }
-
-  // Setup
-  zones.setLocker(locker);
-  zones.setConfig("subscriber", subscriber);
-  zones.setConfig("dma", subscriber ? true : dma);
-  zones.setConfig("ads", locker.getYozonsLocker("core").areAdsAllowed());
-
-  // Config files 
-  if(!locker.config) {
-    locker.config = {
-      homepage: "/static/hi/zones/homepage.json",
-      sectfront: "/static/hi/zones/section.json",
-      story: "/static/hi/zones/story.json"
+    // DSP limited to production domains
+    try {
+      subscriber = locker.user.isSubscriber();
+      dma = await locker.user.isInDMA();
+    } catch(e) {
+      subscriber = false;
+      dma = false
+      console.warn("DSP is not available");
     }
-  }
 
-  // Add the communication bridge 
-  window.mi = window.mi || {};
-  window.mi.zones = window.mi.zones || {};
-  window.mi.zones = Object.assign(window.mi.zones, zones.getPublicAPI());
+    // Setup
+    zones.setLocker(locker);
+    zones.setConfig("subscriber", subscriber);
+    zones.setConfig("dma", subscriber ? true : dma);
+    zones.setConfig("ads", locker.getYozonsLocker("core").areAdsAllowed());
 
-  // Give the performance team a promise
-  return new Promise((resolve, reject) => {
-    locker.executeWhenDOMReady(async () => {
-      // Config keys match pageType coming from Yozons
-      const match = locker.config[locker.pageType];
+    // Config files 
+    if(!locker.config) {
+      locker.config = {
+        homepage: "/static/hi/zones/homepage.json",
+        sectfront: "/static/hi/zones/section.json",
+        story: "/static/hi/zones/story.json"
+      }
+    }
 
-      // Load config file
-      if(match) {
-        try {
-          await config.load(match);
-        } catch(e) {
-          reject(e);
+    // Add the communication bridge 
+    window.mi = window.mi || {};
+    window.mi.zones = window.mi.zones || {};
+    window.mi.zones = Object.assign(window.mi.zones, zones.getPublicAPI());
+
+    // Give the performance team a promise
+    return new Promise((resolve, reject) => {
+      locker.executeWhenDOMReady(async () => {
+        // Config keys match pageType coming from Yozons
+        const match = locker.config[locker.pageType];
+
+        // Load config file
+        if(match) {
+          try {
+            await config.load(match);
+          } catch(e) {
+            reject(e);
+          }
+        } else {
+          reject("zones: not a matching page type");
         }
-      } else {
-        reject("zones: not a matching page type");
-      }
 
-      // Temporary cleanup
-      if(locker.pageType == "story") {
-        story.cleanup();
-      }
+        // Temporary cleanup
+        if(locker.pageType == "story") {
+          story.cleanup();
+        }
 
-      // Render and resolve
-      zones.render();
-      resolve("zones-loaded")
+        // Render and resolve
+        zones.render();
+        resolve("zones-loaded")
+      });
     });
-  });
+  }
 }
 
 export default distributeZones;

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ import * as story from "./lib/story.js";
 
 async function distributeZones(locker) {
   // Using a section config to scale from this repo to experiences
-  if(locker.getConfig("zones") != "experiences") {
+  // if(locker.getConfig("zones") != "experiences") {
     let subscriber, dma;
 
     // DSP limited to production domains
@@ -68,7 +68,7 @@ async function distributeZones(locker) {
         resolve("zones-loaded")
       });
     });
-  }
+  // }
 }
 
 export default distributeZones;


### PR DESCRIPTION
This PR simply adds a section config check and if `zones == "experiences"` it bails out early doing nothing to the page. 

I'm including my overrides, which includes a full build of Yozons using this code, and I have already set the section config in the KC Special Reports section. You can use the [Lipsum story](http://www.kansascity.com/news/special-reports/article194359649.html) to see a very broken page. Any other page should render normally.

[PE-215-overrides.zip](https://github.com/user-attachments/files/16913297/PE-215-overrides.zip)
